### PR TITLE
Port 4 v8.85-era UX features from stale gitbutler/workspace onto main

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -97,6 +97,44 @@ pub fn detect_agents() -> Vec<AgentKind> {
     found
 }
 
+pub(crate) fn ensure_agent_binary_available(agent_kind: AgentKind, agent_name: &str) -> Result<()> {
+    ensure_agent_binary_available_with(agent_kind, agent_name, env::which_exists)
+}
+
+pub(crate) fn ensure_agent_binary_available_with<F>(
+    agent_kind: AgentKind,
+    agent_name: &str,
+    which: F,
+) -> Result<()>
+where
+    F: Fn(&str) -> bool,
+{
+    if built_in_agent_binary_exists(agent_kind, which) {
+        return Ok(());
+    }
+    anyhow::bail!("Agent '{}' not found: binary missing from PATH", agent_name);
+}
+
+pub(crate) fn built_in_agent_binary_exists<F>(agent_kind: AgentKind, which: F) -> bool
+where
+    F: Fn(&str) -> bool,
+{
+    match agent_kind {
+        AgentKind::Codex => which("codex"),
+        AgentKind::Copilot => which("copilot"),
+        AgentKind::Cursor => which("agent") || which("cursor-agent"),
+        AgentKind::Gemini => which("gemini"),
+        AgentKind::Qwen => which("qwen"),
+        AgentKind::OpenCode => which("opencode"),
+        AgentKind::Kilo => which("kilo"),
+        AgentKind::Codebuff => which("aid-codebuff"),
+        AgentKind::Droid => which("droid"),
+        AgentKind::Oz => which("oz"),
+        AgentKind::Claude => which("claude"),
+        AgentKind::Custom => true,
+    }
+}
+
 pub(crate) fn select_agent_with_reason(
     prompt: &str, opts: &RunOpts, store: &store::Store,
     team: Option<&crate::team::TeamConfig>,
@@ -151,5 +189,33 @@ pub fn embed_context_in_prompt(prompt: &str, context_files: &[String]) -> anyhow
 
 #[cfg(test)]
 mod cursor_binary_tests;
+#[cfg(test)]
+mod binary_preflight_tests {
+    use super::{built_in_agent_binary_exists, ensure_agent_binary_available_with};
+    use crate::types::AgentKind;
+
+    #[test]
+    fn built_in_agent_binary_exists_rejects_missing_kilo_binary() {
+        assert!(!built_in_agent_binary_exists(AgentKind::Kilo, |_| false));
+    }
+
+    #[test]
+    fn built_in_agent_binary_exists_accepts_cursor_alias_binary() {
+        assert!(built_in_agent_binary_exists(AgentKind::Cursor, |name| {
+            name == "cursor-agent"
+        }));
+    }
+
+    #[test]
+    fn ensure_agent_binary_available_reports_missing_path_binary() {
+        let err = ensure_agent_binary_available_with(AgentKind::Kilo, "kilo", |_| false)
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Agent 'kilo' not found: binary missing from PATH"
+        );
+    }
+}
 #[cfg(test)]
 mod tests;

--- a/src/background.rs
+++ b/src/background.rs
@@ -118,6 +118,7 @@ async fn run_task_inner(store: &Arc<Store>, spec: &BackgroundRunSpec) -> Result<
         env: spec.env.clone(),
         env_forward: spec.env_forward.clone(),
     };
+    ensure_agent_binary_available(spec)?;
     let _workspace_symlink = crate::cmd::run::WorkspaceSymlinkGuard::create(
         agent.kind(),
         spec.group.as_deref(),
@@ -382,6 +383,23 @@ fn rescue_files_summary(outcome: &crate::commit::RescueOutcome) -> String {
     files.join(", ")
 }
 
+fn ensure_agent_binary_available(spec: &BackgroundRunSpec) -> Result<()> {
+    ensure_agent_binary_available_with(spec, agent::env::which_exists)
+}
+
+fn ensure_agent_binary_available_with<F>(spec: &BackgroundRunSpec, which: F) -> Result<()>
+where
+    F: Fn(&str) -> bool,
+{
+    if spec.container.is_some() || spec.sandbox {
+        return Ok(());
+    }
+    let Some(kind) = AgentKind::parse_str(&spec.agent_name) else {
+        return Ok(());
+    };
+    agent::ensure_agent_binary_available_with(kind, &spec.agent_name, which)
+}
+
 fn record_worker_failure(store: &Store, task_id: &str, err: &anyhow::Error) -> Result<()> { record_failure(store, task_id, &format!("{err:#}"), &format!("Background worker failed: {err}")) }
 
 fn check_zombie_tasks_with<F>(store: &Store, is_worker_alive: F) -> Result<Vec<String>>
@@ -567,5 +585,8 @@ fn notify_task_completion(store: &Store, task_id: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+#[path = "background_binary_tests.rs"]
+mod background_binary_tests;
 #[cfg(test)]
 mod tests;

--- a/src/background_binary_tests.rs
+++ b/src/background_binary_tests.rs
@@ -1,0 +1,66 @@
+// Tests for background agent binary preflight behavior.
+// Covers missing built-in agent binaries before command construction.
+// Deps: background run specs and AgentKind parsing.
+
+use super::{ensure_agent_binary_available_with, BackgroundRunSpec};
+
+#[test]
+fn background_preflight_rejects_missing_kilo_binary() {
+    let spec = BackgroundRunSpec {
+        agent_name: "kilo".to_string(),
+        ..make_spec("t-kilo")
+    };
+
+    let err = ensure_agent_binary_available_with(&spec, |_| false).unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Agent 'kilo' not found: binary missing from PATH"
+    );
+}
+
+#[test]
+fn background_preflight_skips_containerized_runs() {
+    let spec = BackgroundRunSpec {
+        agent_name: "kilo".to_string(),
+        container: Some("ubuntu:latest".to_string()),
+        ..make_spec("t-kilo")
+    };
+
+    ensure_agent_binary_available_with(&spec, |_| false).unwrap();
+}
+
+fn make_spec(task_id: &str) -> BackgroundRunSpec {
+    BackgroundRunSpec {
+        task_id: task_id.to_string(),
+        worker_pid: None,
+        agent_name: "codex".to_string(),
+        prompt: "prompt".to_string(),
+        dir: Some(".".to_string()),
+        output: None,
+        result_file: None,
+        model: None,
+        verify: None,
+        iterate: None,
+        eval: None,
+        eval_feedback_template: None,
+        judge: None,
+        max_duration_mins: None,
+        idle_timeout_secs: None,
+        retry: 0,
+        group: None,
+        skills: vec![],
+        checklist: vec![],
+        template: None,
+        interactive: true,
+        on_done: None,
+        cascade: vec![],
+        parent_task_id: None,
+        env: None,
+        env_forward: None,
+        agent_pid: None,
+        sandbox: false,
+        read_only: false,
+        container: None,
+    }
+}

--- a/src/background_binary_tests.rs
+++ b/src/background_binary_tests.rs
@@ -41,6 +41,7 @@ fn make_spec(task_id: &str) -> BackgroundRunSpec {
         result_file: None,
         model: None,
         verify: None,
+        setup: None,
         iterate: None,
         eval: None,
         eval_feedback_template: None,
@@ -62,5 +63,7 @@ fn make_spec(task_id: &str) -> BackgroundRunSpec {
         sandbox: false,
         read_only: false,
         container: None,
+        link_deps: false,
+        pre_task_dirty_paths: None,
     }
 }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -40,7 +40,8 @@ pub fn warn_dir_overlap(tasks: &[BatchTask]) -> Vec<String> {
 }
 
 pub fn parse_batch_file(path: &Path) -> Result<BatchConfig> {
-    parse_batch_file_with_vars(path, &HashMap::new())
+    let current_dir = std::env::current_dir().ok();
+    parse_batch_file_with_vars_and_source(path, &HashMap::new(), Some(path), current_dir.as_deref())
 }
 
 fn validate_batch_keys(content: &str, path: &Path) -> Result<()> {
@@ -72,6 +73,16 @@ pub(crate) fn parse_batch_file_with_vars(
     path: &Path,
     cli_vars: &HashMap<String, String>,
 ) -> Result<BatchConfig> {
+    let current_dir = std::env::current_dir().ok();
+    parse_batch_file_with_vars_and_source(path, cli_vars, Some(path), current_dir.as_deref())
+}
+
+pub(crate) fn parse_batch_file_with_vars_and_source(
+    path: &Path,
+    cli_vars: &HashMap<String, String>,
+    source_path: Option<&Path>,
+    pwd: Option<&Path>,
+) -> Result<BatchConfig> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read batch file: {}", path.display()))?;
     validate_batch_keys(&content, path)?;
@@ -84,8 +95,9 @@ pub(crate) fn parse_batch_file_with_vars(
     let mut stderr = io::stderr().lock();
     interpolate_batch_config(&mut config, cli_vars, &mut stderr)?;
     apply_defaults(&mut config.tasks, &config.defaults);
-    resolve_batch_paths(&mut config.tasks, path);
-    resolve_task_prompts(&mut config.tasks, path)?;
+    let batch_dir = batch_source_dir(source_path, pwd);
+    resolve_batch_paths(&mut config.tasks, batch_dir.as_deref(), pwd)?;
+    resolve_task_prompts(&mut config.tasks, batch_dir.as_deref(), pwd)?;
     validate_agents(&config.tasks)?;
     validate_fallback_agents(&config.tasks)?;
     auto_sequence_shared_worktrees(&mut config.tasks, &mut stderr)?;
@@ -96,29 +108,99 @@ pub(crate) fn parse_batch_file_with_vars(
     Ok(config)
 }
 
-fn resolve_batch_paths(tasks: &mut [BatchTask], batch_path: &Path) {
-    let base_dir = batch_path.parent().unwrap_or_else(|| Path::new("."));
+fn batch_source_dir(source_path: Option<&Path>, pwd: Option<&Path>) -> Option<PathBuf> {
+    let parent = source_path?.parent()?;
+    if parent.as_os_str().is_empty() {
+        return None;
+    }
+    Some(if parent.is_absolute() {
+        parent.to_path_buf()
+    } else if let Some(pwd) = pwd {
+        pwd.join(parent)
+    } else {
+        parent.to_path_buf()
+    })
+}
+
+fn resolve_batch_paths(tasks: &mut [BatchTask], batch_dir: Option<&Path>, pwd: Option<&Path>) -> Result<()> {
     for task in tasks {
         if let Some(dir) = task.dir.as_mut() {
-            resolve_batch_path(base_dir, dir);
+            resolve_batch_path("dir", dir, batch_dir, pwd)?;
         }
         if let Some(context) = task.context.as_mut() {
             for entry in context {
-                resolve_batch_path(base_dir, entry);
+                resolve_batch_context_path(entry, batch_dir, pwd)?;
             }
         }
     }
+    Ok(())
 }
 
-fn resolve_batch_path(base_dir: &Path, value: &mut String) {
-    let path = Path::new(value);
-    if !value.is_empty() && path.is_relative() {
-        *value = base_dir.join(path).to_string_lossy().into_owned();
+fn resolve_batch_path(field: &str, value: &mut String, batch_dir: Option<&Path>, pwd: Option<&Path>) -> Result<()> {
+    let raw_value = value.clone();
+    let path = Path::new(&raw_value);
+    if !raw_value.is_empty() && path.is_relative() {
+        *value = resolve_relative_batch_path(field, &raw_value, path, None, batch_dir, pwd)?;
+    }
+    Ok(())
+}
+
+fn resolve_batch_context_path(value: &mut String, batch_dir: Option<&Path>, pwd: Option<&Path>) -> Result<()> {
+    let raw_value = value.clone();
+    let (file, item) = match raw_value.split_once(':') {
+        Some((file, item)) => (file, Some(item)),
+        None => (raw_value.as_str(), None),
+    };
+    let path = Path::new(file);
+    if !file.is_empty() && path.is_relative() {
+        *value = resolve_relative_batch_path("context", &raw_value, path, item, batch_dir, pwd)?;
+    }
+    Ok(())
+}
+
+fn resolve_relative_batch_path(
+    field: &str,
+    raw_value: &str,
+    relative_path: &Path,
+    item: Option<&str>,
+    batch_dir: Option<&Path>,
+    pwd: Option<&Path>,
+) -> Result<String> {
+    if let Some(candidate) = batch_dir.map(|dir| dir.join(relative_path))
+        && candidate.exists()
+    {
+        return Ok(with_context_item(candidate, item));
+    }
+    if let Some(candidate) = pwd.map(|dir| dir.join(relative_path))
+        && candidate.exists()
+    {
+        return Ok(with_context_item(candidate, item));
+    }
+
+    let toml_attempt = attempted_path(batch_dir, relative_path, "<toml-dir unavailable>");
+    let pwd_attempt = attempted_path(pwd, relative_path, "<pwd unavailable>");
+    anyhow::bail!(
+        "{field} = '{}' in batch TOML could not be resolved: tried {toml_attempt} and {pwd_attempt} — use an absolute path or place the TOML inside the target repo",
+        raw_value
+    );
+}
+
+fn attempted_path(base_dir: Option<&Path>, relative_path: &Path, fallback: &str) -> String {
+    match base_dir {
+        Some(dir) => dir.join(relative_path).display().to_string(),
+        None => format!("{fallback}/{}", relative_path.display()),
     }
 }
 
-fn resolve_task_prompts(tasks: &mut [BatchTask], batch_path: &Path) -> Result<()> {
-    let base_dir = batch_path.parent().unwrap_or_else(|| Path::new("."));
+fn with_context_item(path: PathBuf, item: Option<&str>) -> String {
+    let normalized: PathBuf = path.components().collect();
+    match item {
+        Some(item) => format!("{}:{item}", normalized.to_string_lossy()),
+        None => normalized.to_string_lossy().into_owned(),
+    }
+}
+
+fn resolve_task_prompts(tasks: &mut [BatchTask], batch_dir: Option<&Path>, pwd: Option<&Path>) -> Result<()> {
     for (task_idx, task) in tasks.iter_mut().enumerate() {
         let has_prompt = !task.prompt.trim().is_empty();
         match (task.prompt_file.as_deref(), has_prompt) {
@@ -131,7 +213,7 @@ fn resolve_task_prompts(tasks: &mut [BatchTask], batch_path: &Path) -> Result<()
                 task_label(task, task_idx)
             ),
             (Some(file), false) => {
-                let prompt_path = batch_prompt_path(base_dir, file);
+                let prompt_path = batch_prompt_path(batch_dir, pwd, file)?;
                 task.prompt = std::fs::read_to_string(&prompt_path).with_context(|| {
                     format!(
                         "failed to read prompt file for task {}: {}",
@@ -146,12 +228,19 @@ fn resolve_task_prompts(tasks: &mut [BatchTask], batch_path: &Path) -> Result<()
     Ok(())
 }
 
-fn batch_prompt_path(base_dir: &Path, file: &str) -> PathBuf {
+fn batch_prompt_path(batch_dir: Option<&Path>, pwd: Option<&Path>, file: &str) -> Result<PathBuf> {
     let path = Path::new(file);
     if path.is_absolute() {
-        path.to_path_buf()
+        Ok(path.to_path_buf())
     } else {
-        base_dir.join(path)
+        Ok(PathBuf::from(resolve_relative_batch_path(
+            "prompt_file",
+            file,
+            path,
+            None,
+            batch_dir,
+            pwd,
+        )?))
     }
 }
 

--- a/src/batch/tests.rs
+++ b/src/batch/tests.rs
@@ -91,6 +91,7 @@ fn parse_valid_batch() {
             "[[tasks]]\nagent = \"gemini\"\nprompt = \"research X\"\nworktree = \"feat/x\"\n",
             "[[tasks]]\nagent = \"codex\"\nprompt = \"implement Y\"\ndir = \"src\"\nmodel = \"gpt-4\"\ngroup = \"wg-demo\""
         ));
+    std::fs::create_dir_all(file.path().parent().unwrap().join("src")).unwrap();
     let cfg = parse_batch_file(file.path()).unwrap();
     let expected_dir = file.path().parent().unwrap().join("src");
 
@@ -293,8 +294,11 @@ fn applies_defaults_to_tasks() {
             "env_forward = [\"PATH\"]\n",
             "[[tasks]]\nname = \"impl\"\nprompt = \"build it\"\n"
         ));
-    let cfg = parse_batch_file(file.path()).unwrap();
     let batch_dir = file.path().parent().unwrap();
+    std::fs::create_dir_all(batch_dir.join("src")).unwrap();
+    std::fs::write(batch_dir.join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    std::fs::write(batch_dir.join("src/main.rs"), "fn run() {}\n").unwrap();
+    let cfg = parse_batch_file(file.path()).unwrap();
 
     assert_eq!(cfg.defaults.auto_fallback, Some(true));
     let task = &cfg.tasks[0];
@@ -369,8 +373,11 @@ fn task_values_override_defaults() {
             "env = { SHARED = \"task\", TASK_ONLY = \"set\" }\n",
             "env_forward = [\"HOME\"]\n"
         ));
-    let cfg = parse_batch_file(file.path()).unwrap();
     let batch_dir = file.path().parent().unwrap();
+    std::fs::create_dir_all(batch_dir.join("custom")).unwrap();
+    std::fs::create_dir_all(batch_dir.join("src")).unwrap();
+    std::fs::write(batch_dir.join("src/task.rs"), "pub fn task() {}\n").unwrap();
+    let cfg = parse_batch_file(file.path()).unwrap();
 
     let task = &cfg.tasks[0];
     assert_eq!(task.agent, "codex");
@@ -426,6 +433,7 @@ fn resolve_batch_paths_resolves_relative_dir_from_batch_parent() {
     let temp = tempdir().unwrap();
     let batch_dir = temp.path().join("batches");
     std::fs::create_dir_all(&batch_dir).unwrap();
+    std::fs::create_dir_all(batch_dir.join("subdir")).unwrap();
     let batch_path = write_batch_file(
         &batch_dir,
         "tasks.toml",
@@ -446,6 +454,7 @@ fn resolve_batch_paths_leaves_absolute_dir_unchanged() {
     let batch_dir = temp.path().join("batches");
     std::fs::create_dir_all(&batch_dir).unwrap();
     let absolute_dir = temp.path().join("absolute-dir");
+    std::fs::create_dir_all(&absolute_dir).unwrap();
     let batch_path = write_batch_file(
         &batch_dir,
         "tasks.toml",
@@ -466,6 +475,8 @@ fn resolve_batch_paths_resolves_context_entries() {
     let batch_dir = temp.path().join("batches");
     std::fs::create_dir_all(&batch_dir).unwrap();
     let absolute_context = temp.path().join("global.md");
+    std::fs::write(batch_dir.join("notes.md"), "notes\n").unwrap();
+    std::fs::write(&absolute_context, "global\n").unwrap();
     let batch_path = write_batch_file(
         &batch_dir,
         "tasks.toml",
@@ -489,17 +500,81 @@ fn resolve_batch_paths_resolves_context_entries() {
 }
 
 #[test]
-fn resolve_batch_paths_handles_batch_file_in_current_dir() {
-    let mut tasks = [BatchTask {
-        dir: Some("subdir".to_string()),
-        context: Some(vec!["notes.md".to_string()]),
-        ..make_task(Some("task"), &[])
-    }];
+fn resolve_batch_paths_resolves_dot_relative_to_toml_dir() {
+    let temp = tempdir().unwrap();
+    let repo_dir = temp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    let batch_path = write_batch_file(
+        &repo_dir,
+        "tasks.toml",
+        "[[tasks]]\nagent = \"codex\"\nprompt = \"test\"\ndir = \".\"\n",
+    );
 
-    resolve_batch_paths(&mut tasks, Path::new("tasks.toml"));
+    let cfg = parse_batch_file(&batch_path).unwrap();
 
-    assert_eq!(tasks[0].dir.as_deref(), Some("subdir"));
-    assert_eq!(tasks[0].context.as_deref(), Some(&["notes.md".to_string()][..]));
+    assert_eq!(cfg.tasks[0].dir.as_deref(), Some(repo_dir.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn resolve_batch_paths_fall_back_to_pwd_when_source_path_is_unavailable() {
+    let temp = tempdir().unwrap();
+    let pwd = temp.path().join("repo");
+    std::fs::create_dir_all(pwd.join("project")).unwrap();
+    std::fs::write(pwd.join("notes.md"), "notes\n").unwrap();
+    let archived_batch = write_batch_file(
+        temp.path(),
+        "archived.toml",
+        "[[tasks]]\nagent = \"codex\"\nprompt = \"test\"\ndir = \"project\"\ncontext = [\"notes.md\"]\n",
+    );
+
+    let cfg = parse_batch_file_with_vars_and_source(
+        &archived_batch,
+        &std::collections::HashMap::new(),
+        None,
+        Some(&pwd),
+    )
+    .unwrap();
+
+    assert_eq!(
+        cfg.tasks[0].dir.as_deref(),
+        Some(pwd.join("project").to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        cfg.tasks[0].context.as_deref(),
+        Some(&[pwd.join("notes.md").to_string_lossy().into_owned()][..])
+    );
+}
+
+#[test]
+fn resolve_batch_paths_errors_when_relative_dir_cannot_be_resolved() {
+    let temp = tempdir().unwrap();
+    let batch_dir = temp.path().join("batches");
+    let pwd = temp.path().join("repo");
+    std::fs::create_dir_all(&batch_dir).unwrap();
+    std::fs::create_dir_all(&pwd).unwrap();
+    let batch_path = write_batch_file(
+        &batch_dir,
+        "tasks.toml",
+        "[[tasks]]\nagent = \"codex\"\nprompt = \"test\"\ndir = \"missing\"\n",
+    );
+
+    let err = parse_batch_file_with_vars_and_source(
+        &batch_path,
+        &std::collections::HashMap::new(),
+        Some(&batch_path),
+        Some(&pwd),
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert_eq!(
+        err,
+        format!(
+            "dir = 'missing' in batch TOML could not be resolved: tried {} and {} — use an absolute path or place the TOML inside the target repo",
+            batch_dir.join("missing").display(),
+            pwd.join("missing").display()
+        )
+    );
 }
 
 #[test]

--- a/src/cli/command_args_b.rs
+++ b/src/cli/command_args_b.rs
@@ -90,6 +90,8 @@ pub struct MergeArgs {
     pub approve: bool,
     #[arg(long)]
     pub check: bool,
+    #[arg(long, help = "Allow merging a task in FAIL or STOPPED state (use when the task's code changes are good but verify failed).")]
+    pub force: bool,
     #[arg(long, help = "Merge into this branch instead of current")]
     pub target: Option<String>,
     #[arg(long, help = "Apply group task branches as GitButler virtual branch lanes")]

--- a/src/cli_actions.rs
+++ b/src/cli_actions.rs
@@ -80,6 +80,8 @@ pub enum GroupAction {
     /// Delete a workgroup definition
     Delete {
         group_id: String,
+        #[arg(long)]
+        cascade: bool,
     },
     /// Cancel all non-terminal tasks in a workgroup
     Cancel {

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -58,13 +58,23 @@ pub async fn run(store: Arc<Store>, args: BatchArgs) -> Result<()> {
     if args.max_concurrent == Some(0) {
         anyhow::bail!("--max-concurrent must be at least 1");
     }
-    let resolved_path = batch_helpers::resolve_batch_path(Path::new(&args.file));
+    let requested_path = Path::new(&args.file);
+    let source_path = requested_path.exists().then_some(requested_path);
+    let invoked_pwd = std::env::current_dir().ok();
+    let resolved_path = batch_helpers::resolve_batch_path(requested_path);
     let path = resolved_path.as_path();
     let cli_vars = parse_cli_vars(&args.vars)?;
-    let mut config = if cli_vars.is_empty() {
+    let mut config = if source_path == Some(path) && cli_vars.is_empty() {
         batch::parse_batch_file(path)
-    } else {
+    } else if source_path == Some(path) {
         batch::parse_batch_file_with_vars(path, &cli_vars)
+    } else {
+        batch::parse_batch_file_with_vars_and_source(
+            path,
+            &cli_vars,
+            source_path,
+            invoked_pwd.as_deref(),
+        )
     }
     .with_context(|| format!("Failed to load batch file {}", path.display()))?;
     let max_concurrent = args.max_concurrent.or(config.defaults.max_concurrent);

--- a/src/cmd/group.rs
+++ b/src/cmd/group.rs
@@ -113,12 +113,23 @@ pub fn update(
     Ok(())
 }
 
-pub fn delete(store: &Arc<Store>, workgroup_id: &str) -> Result<()> {
+pub fn delete(store: &Arc<Store>, workgroup_id: &str, cascade: bool) -> Result<()> {
+    if cascade {
+        let deleted_tasks = store
+            .delete_workgroup_cascade(workgroup_id)?
+            .ok_or_else(|| anyhow::anyhow!("Workgroup '{}' not found", workgroup_id))?;
+        println!("Deleted {} tasks and group {}", deleted_tasks, workgroup_id);
+        return Ok(());
+    }
+
     let tagged_tasks = store
         .delete_workgroup(workgroup_id)?
         .ok_or_else(|| anyhow::anyhow!("Workgroup '{}' not found", workgroup_id))?;
     println!("Workgroup {} deleted", workgroup_id);
-    println!("Historical tasks still tagged: {}", tagged_tasks);
+    println!(
+        "Historical tasks still tagged: {} — use --cascade to also delete them",
+        tagged_tasks
+    );
     Ok(())
 }
 
@@ -217,5 +228,37 @@ mod tests {
         assert_eq!(store.get_task("t-run").unwrap().unwrap().status, TaskStatus::Stopped);
         assert_eq!(store.get_task("t-done").unwrap().unwrap().status, TaskStatus::Done);
         assert_eq!(store.get_task("t-other").unwrap().unwrap().status, TaskStatus::Running);
+    }
+
+    #[test]
+    fn delete_group_without_cascade_keeps_tagged_tasks() {
+        let temp = TempDir::new().unwrap();
+        let _guard = AidHomeGuard::set(temp.path());
+        let store = Arc::new(Store::open_memory().unwrap());
+        store.create_workgroup("demo", "", Some("cli"), Some("wg-1")).unwrap();
+        store
+            .insert_task(&make_task("t-keep", "wg-1", TaskStatus::Done))
+            .unwrap();
+
+        delete(&store, "wg-1", false).unwrap();
+
+        assert!(store.get_workgroup("wg-1").unwrap().is_none());
+        assert!(store.get_task("t-keep").unwrap().is_some());
+    }
+
+    #[test]
+    fn delete_group_with_cascade_removes_group_and_tasks() {
+        let temp = TempDir::new().unwrap();
+        let _guard = AidHomeGuard::set(temp.path());
+        let store = Arc::new(Store::open_memory().unwrap());
+        store.create_workgroup("demo", "", Some("cli"), Some("wg-1")).unwrap();
+        store
+            .insert_task(&make_task("t-drop", "wg-1", TaskStatus::Done))
+            .unwrap();
+
+        delete(&store, "wg-1", true).unwrap();
+
+        assert!(store.get_workgroup("wg-1").unwrap().is_none());
+        assert!(store.get_task("t-drop").unwrap().is_none());
     }
 }

--- a/src/cmd/merge.rs
+++ b/src/cmd/merge.rs
@@ -1,12 +1,13 @@
 // Handler for `aid merge` — mark done task(s) as merged, optionally by workgroup.
 // Exports: run()
-// Deps: crate::store::Store, crate::types::TaskStatus
+// Deps: chrono, crate::store::Store, crate::types
 
 use anyhow::{anyhow, Result};
+use chrono::Local;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use crate::store::Store;
-use crate::types::{Task, TaskStatus, VerifyStatus};
+use crate::types::{EventKind, Task, TaskEvent, TaskId, TaskStatus, VerifyStatus};
 #[path = "merge_git.rs"]
 pub(crate) mod merge_git;
 use merge_git::*;
@@ -14,7 +15,7 @@ pub use merge_git::remove_worktree;
 #[path = "merge_lanes.rs"]
 mod merge_lanes;
 
-pub fn run(store: Arc<Store>, task_id: Option<&str>, group: Option<&str>, approve: bool, check: bool, target: Option<&str>, lanes: bool) -> Result<()> {
+pub fn run(store: Arc<Store>, task_id: Option<&str>, group: Option<&str>, approve: bool, check: bool, force: bool, target: Option<&str>, lanes: bool) -> Result<()> {
     if lanes {
         let Some(group_id) = group else {
             return Err(anyhow!("--lanes requires --group"));
@@ -28,17 +29,18 @@ pub fn run(store: Arc<Store>, task_id: Option<&str>, group: Option<&str>, approv
         return merge_lanes::merge_group_lanes(&store, group_id);
     }
     match (task_id, group) {
-        (Some(id), _) => merge_single(&store, id, approve, check, target),
+        (Some(id), _) => merge_single(&store, id, approve, check, force, target),
         (_, Some(group_id)) => merge_group(&store, group_id, approve, check, target),
         (None, None) => Err(anyhow!("Provide either a task ID or --group <wg-id>")),
     }
 }
 
-fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target: Option<&str>) -> Result<()> {
+fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, force: bool, target: Option<&str>) -> Result<()> {
     let task = store
         .get_task(task_id)?
         .ok_or_else(|| anyhow!("Task '{task_id}' not found"))?;
-    if task.status != TaskStatus::Done {
+    let original_status = task.status;
+    if task.status != TaskStatus::Done && (!force || !matches!(task.status, TaskStatus::Failed | TaskStatus::Stopped)) {
         return Err(anyhow!(
             "Task '{task_id}' is {} — only DONE tasks can be marked as merged",
             task.status.label()
@@ -51,7 +53,8 @@ fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target
     let repo_dir = resolve_repo_dir(task.repo_path.as_deref(), task.worktree_path.as_deref());
     if check { return check_single(task_id, &task, &repo_dir); }
 
-    if let Some(wt) = task.worktree_path.as_deref()
+    if !force
+        && let Some(wt) = task.worktree_path.as_deref()
         && std::path::Path::new(wt).exists()
     {
         run_verify_in_worktree(wt, task.verify.as_deref());
@@ -67,7 +70,8 @@ fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target
         }
     }
     if let Some(ref branch) = task.worktree_branch {
-        if let Some(wt) = task.worktree_path.as_deref()
+        if !force
+            && let Some(wt) = task.worktree_path.as_deref()
             && std::path::Path::new(wt).exists()
         {
             auto_commit_uncommitted(wt, branch);
@@ -103,11 +107,15 @@ fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target
                     aid_warn!("  {}", line);
                 }
                 aid_hint!("[aid] Manual merge needed: git merge {branch}");
-                store.update_task_status(task_id, TaskStatus::Done)?;
+                let preserved_status = if force { original_status } else { TaskStatus::Done };
+                store.update_task_status(task_id, preserved_status)?;
                 return Err(anyhow!("Merge failed — resolve manually, then re-run aid merge {task_id}"));
             }
         }
     } else {
+        if force {
+            return Err(anyhow!("Force merge requires a committed worktree branch"));
+        }
         let has_changes = Command::new("git")
             .args(["-C", &repo_dir, "status", "--porcelain"])
             .output()
@@ -121,6 +129,9 @@ fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target
             aid_info!("[aid] In-place edit — no uncommitted changes (may already be committed).");
         }
     }
+    if force {
+        record_force_merge_warning(store, task_id, original_status)?;
+    }
     store.update_task_status(task_id, TaskStatus::Merged)?;
     println!("Marked {task_id} as merged");
     if let Some(wt) = task.worktree_path.as_deref()
@@ -129,6 +140,21 @@ fn merge_single(store: &Store, task_id: &str, approve: bool, check: bool, target
             aid_warn!("[aid] Warning: failed to clean up worktree {wt}: {err}");
         }
     Ok(())
+}
+
+fn record_force_merge_warning(store: &Store, task_id: &str, status: TaskStatus) -> Result<()> {
+    let detail = format!(
+        "Force-merged task {task_id} from status {} — verify/tests were not run",
+        status.label()
+    );
+    aid_warn!("[aid] Warning: {detail}");
+    store.insert_event(&TaskEvent {
+        task_id: TaskId(task_id.to_string()),
+        timestamp: Local::now(),
+        event_kind: EventKind::Error,
+        detail,
+        metadata: None,
+    })
 }
 
 fn merge_group(store: &Store, group_id: &str, approve: bool, check: bool, target: Option<&str>) -> Result<()> {

--- a/src/cmd/merge/tests.rs
+++ b/src/cmd/merge/tests.rs
@@ -584,7 +584,7 @@ fn merge_single_succeeds_with_committed_worktree() {
     let task = make_task_with_worktree("t-merge-ok", repo.path(), wt.path(), &branch);
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-merge-ok", false, false, None);
+    let result = merge_single(&store, "t-merge-ok", false, false, false, None);
     assert!(result.is_ok(), "merge_single failed: {result:?}");
 
     let loaded = store.get_task("t-merge-ok").unwrap().unwrap();
@@ -619,7 +619,7 @@ fn merge_single_auto_commits_then_merges() {
     let task = make_task_with_worktree("t-autocommit", repo.path(), wt.path(), &branch);
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-autocommit", false, false, None);
+    let result = merge_single(&store, "t-autocommit", false, false, false, None);
     assert!(
         result.is_ok(),
         "merge_single should auto-commit and merge: {result:?}"
@@ -656,7 +656,7 @@ fn merge_single_fails_when_no_commits_and_no_changes() {
     let task = make_task_with_worktree("t-empty", repo.path(), wt.path(), &branch);
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-empty", false, false, None);
+    let result = merge_single(&store, "t-empty", false, false, false, None);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -689,9 +689,67 @@ fn merge_single_rejects_non_done_task() {
     task.status = TaskStatus::Running;
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-running", false, false, None);
+    let result = merge_single(&store, "t-running", false, false, false, None);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("only DONE"));
+}
+
+#[test]
+fn merge_single_rejects_failed_task_without_force() {
+    let _permit = test_subprocess::acquire();
+    let store = Store::open_memory().unwrap();
+    let mut task = make_task_with_worktree("t-failed", Path::new("."), Path::new("/tmp"), "b");
+    task.status = TaskStatus::Failed;
+    store.insert_task(&task).unwrap();
+
+    let result = merge_single(&store, "t-failed", false, false, false, None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("only DONE"));
+}
+
+#[test]
+fn merge_single_force_merges_failed_task_with_committed_branch() {
+    let _permit = test_subprocess::acquire();
+    let repo = init_repo();
+    let (wt, branch) = create_worktree_with_commit(repo.path());
+    let store = Store::open_memory().unwrap();
+    let mut task = make_task_with_worktree("t-force-failed", repo.path(), wt.path(), &branch);
+    task.status = TaskStatus::Failed;
+    store.insert_task(&task).unwrap();
+
+    let result = merge_single(&store, "t-force-failed", false, false, true, None);
+    assert!(result.is_ok(), "force merge failed: {result:?}");
+
+    let loaded = store.get_task("t-force-failed").unwrap().unwrap();
+    assert_eq!(loaded.status, TaskStatus::Merged);
+    assert!(repo.path().join("agent-work.txt").exists());
+    let events = store.get_events("t-force-failed").unwrap();
+    assert!(events.iter().any(|event| {
+        event.event_kind == EventKind::Error
+            && event.detail == "Force-merged task t-force-failed from status FAIL — verify/tests were not run"
+    }));
+}
+
+#[test]
+fn merge_single_force_rejects_failed_task_without_commits() {
+    let _permit = test_subprocess::acquire();
+    let repo = init_repo();
+    let (wt, branch) = create_empty_worktree_branch(repo.path());
+    let store = Store::open_memory().unwrap();
+    let mut task = make_task_with_worktree("t-force-empty", repo.path(), wt.path(), &branch);
+    task.status = TaskStatus::Failed;
+    store.insert_task(&task).unwrap();
+
+    let result = merge_single(&store, "t-force-empty", false, false, true, None);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("No commits to merge"), "unexpected error: {err}");
+
+    let loaded = store.get_task("t-force-empty").unwrap().unwrap();
+    assert_eq!(loaded.status, TaskStatus::Failed);
+    assert!(wt.path().exists());
+
+    git(repo.path(), &["worktree", "remove", "--force", &wt.path().to_string_lossy()]);
 }
 
 #[test]
@@ -736,7 +794,7 @@ fn merge_single_works_without_worktree_branch() {
     };
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-inplace", false, false, None);
+    let result = merge_single(&store, "t-inplace", false, false, false, None);
     assert!(result.is_ok());
     let loaded = store.get_task("t-inplace").unwrap().unwrap();
     assert_eq!(loaded.status, TaskStatus::Merged);
@@ -770,7 +828,7 @@ fn merge_single_preserves_worktree_on_conflict() {
     let task = make_task_with_worktree("t-conflict", repo.path(), wt.path(), &branch);
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-conflict", false, false, None);
+    let result = merge_single(&store, "t-conflict", false, false, false, None);
     assert!(result.is_err());
     // Worktree must be preserved for manual resolution
     assert!(wt.path().exists());
@@ -803,7 +861,7 @@ fn merge_single_without_repo_path_resolves_from_worktree() {
     task.repo_path = None;
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-no-repo", false, false, None);
+    let result = merge_single(&store, "t-no-repo", false, false, false, None);
     assert!(
         result.is_ok(),
         "merge should resolve repo from worktree: {result:?}"
@@ -822,7 +880,7 @@ fn merge_single_merges_into_target_branch() {
     let task = make_task_with_worktree("t-target", repo.path(), wt.path(), &branch);
     store.insert_task(&task).unwrap();
 
-    let result = merge_single(&store, "t-target", false, false, Some(&target));
+    let result = merge_single(&store, "t-target", false, false, false, Some(&target));
     assert!(result.is_ok(), "merge_single failed: {result:?}");
 
     let current = Command::new("git")
@@ -893,7 +951,7 @@ fn merge_group_skips_empty_branches() {
 #[test]
 fn run_rejects_lanes_without_group() {
     let store = Arc::new(Store::open_memory().unwrap());
-    let result = run(store, None, None, false, false, None, true);
+    let result = run(store, None, None, false, false, false, None, true);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "--lanes requires --group");
 }
@@ -908,6 +966,7 @@ fn run_rejects_unsupported_lanes_flags() {
         Some("wg-lanes"),
         false,
         true,
+        false,
         None,
         true,
     );
@@ -921,6 +980,7 @@ fn run_rejects_unsupported_lanes_flags() {
         store,
         None,
         Some("wg-lanes"),
+        false,
         false,
         false,
         Some("release"),
@@ -953,6 +1013,7 @@ fn run_rejects_lanes_when_gitbutler_env_is_disabled() {
         store,
         None,
         Some("wg-lanes-disabled"),
+        false,
         false,
         false,
         None,

--- a/src/cmd/run_dispatch.rs
+++ b/src/cmd/run_dispatch.rs
@@ -4,12 +4,12 @@
 use anyhow::Result;
 use chrono::Local;
 use std::sync::Arc;
-use crate::agent::env::which_exists;
+use crate::agent;
 use crate::hooks;
 use crate::cmd::show;
 use crate::store::Store;
 use crate::store::TaskCompletionUpdate;
-use crate::types::{AgentKind, EventKind, TaskEvent, TaskId, TaskStatus};
+use crate::types::{EventKind, TaskEvent, TaskId, TaskStatus};
 use super::run_bestof;
 use super::run_dispatch_execute::{
     load_runtime_hooks, maybe_record_start_sha, maybe_start_container, run_background_task,
@@ -87,52 +87,34 @@ fn ensure_agent_binary_available(
     prepared: &PreparedDispatch,
     args: &RunArgs,
 ) -> Result<()> {
-    if args.container.is_some()
-        || args.sandbox
-        || built_in_agent_binary_exists(prepared.agent_kind, which_exists)
-    {
+    if args.container.is_some() || args.sandbox {
         return Ok(());
     }
-    let detail = format!("Agent {} not found. Is it installed?", prepared.agent_display_name);
-    store.complete_task_atomic(
-        TaskCompletionUpdate {
-            id: prepared.task_id.as_str(),
-            status: TaskStatus::Failed,
-            tokens: None,
-            duration_ms: 0,
-            model: prepared.effective_model.as_deref(),
-            cost_usd: None,
-            exit_code: None,
-        },
-        &TaskEvent {
-            task_id: prepared.task_id.clone(),
-            timestamp: Local::now(),
-            event_kind: EventKind::Error,
-            detail: detail.clone(),
-            metadata: None,
-        },
-    )?;
-    Err(anyhow::anyhow!(detail))
-}
-
-fn built_in_agent_binary_exists<F>(agent_kind: AgentKind, which: F) -> bool
-where
-    F: Fn(&str) -> bool,
-{
-    match agent_kind {
-        AgentKind::Codex => which("codex"),
-        AgentKind::Copilot => which("copilot"),
-        AgentKind::Cursor => which("agent") || which("cursor-agent"),
-        AgentKind::Gemini => which("gemini"),
-        AgentKind::Qwen => which("qwen"),
-        AgentKind::OpenCode => which("opencode"),
-        AgentKind::Kilo => which("kilo"),
-        AgentKind::Codebuff => which("aid-codebuff"),
-        AgentKind::Droid => which("droid"),
-        AgentKind::Oz => which("oz"),
-        AgentKind::Claude => which("claude"),
-        AgentKind::Custom => true,
+    if let Err(err) =
+        agent::ensure_agent_binary_available(prepared.agent_kind, &prepared.agent_display_name)
+    {
+        let detail = err.to_string();
+        store.complete_task_atomic(
+            TaskCompletionUpdate {
+                id: prepared.task_id.as_str(),
+                status: TaskStatus::Failed,
+                tokens: None,
+                duration_ms: 0,
+                model: prepared.effective_model.as_deref(),
+                cost_usd: None,
+                exit_code: None,
+            },
+            &TaskEvent {
+                task_id: prepared.task_id.clone(),
+                timestamp: Local::now(),
+                event_kind: EventKind::Error,
+                detail,
+                metadata: None,
+            },
+        )?;
+        return Err(err);
     }
+    Ok(())
 }
 
 fn dry_run(
@@ -193,22 +175,4 @@ fn run_before_hook(
         return Err(err);
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::built_in_agent_binary_exists;
-    use crate::types::AgentKind;
-
-    #[test]
-    fn built_in_agent_binary_exists_rejects_missing_kilo_binary() {
-        assert!(!built_in_agent_binary_exists(AgentKind::Kilo, |_| false));
-    }
-
-    #[test]
-    fn built_in_agent_binary_exists_accepts_cursor_alias_binary() {
-        assert!(built_in_agent_binary_exists(AgentKind::Cursor, |name| {
-            name == "cursor-agent"
-        }));
-    }
 }

--- a/src/cmd_dispatch/dispatch_match.rs
+++ b/src/cmd_dispatch/dispatch_match.rs
@@ -95,8 +95,8 @@ async fn dispatch_primary(store: Arc<crate::store::Store>, command: Commands) ->
 async fn dispatch_secondary(store: Arc<crate::store::Store>, command: Commands) -> Result<()> {
     match command {
         Commands::Retry(command_args_b::RetryArgs { task_id, feedback, agent, dir, reset }) => handlers_b::retry(store, task_id, feedback, agent, dir, reset).await,
-        Commands::Merge(command_args_b::MergeArgs { task_id, group, approve, check, target, lanes }) => {
-            handlers_b::merge(store, task_id, group, approve, check, target, lanes)
+        Commands::Merge(command_args_b::MergeArgs { task_id, group, approve, check, force, target, lanes }) => {
+            handlers_b::merge(store, task_id, group, approve, check, force, target, lanes)
         }
         Commands::Respond(command_args_b::RespondArgs { task_id, input, file }) => handlers_b::respond(task_id, input, file),
         Commands::Stop(command_args_b::StopArgs { task_id, force }) => handlers_b::stop(store, task_id, force),

--- a/src/cmd_dispatch/handlers_b.rs
+++ b/src/cmd_dispatch/handlers_b.rs
@@ -140,7 +140,7 @@ pub(super) fn group(store: Arc<store::Store>, action: GroupAction) -> Result<()>
         GroupAction::Update { group_id, name, context } => {
             cmd::group::update(&store, &group_id, name.as_deref(), context.as_deref())
         }
-        GroupAction::Delete { group_id } => cmd::group::delete(&store, &group_id),
+        GroupAction::Delete { group_id, cascade } => cmd::group::delete(&store, &group_id, cascade),
         GroupAction::Cancel { group_id } => cmd::group::cancel(&store, &group_id),
         GroupAction::Summary { group_id } => cmd::summary_cli::run(&store, &group_id),
         GroupAction::Finding { action } => group_finding(store, action),

--- a/src/cmd_dispatch/handlers_b.rs
+++ b/src/cmd_dispatch/handlers_b.rs
@@ -72,6 +72,7 @@ pub(super) fn merge(
     group: Option<String>,
     approve: bool,
     check: bool,
+    force: bool,
     target: Option<String>,
     lanes: bool,
 ) -> Result<()> {
@@ -79,7 +80,7 @@ pub(super) fn merge(
         return Err(anyhow!("--lanes requires --group"));
     }
     let group = resolve_group(group);
-    cmd::merge::run(store, task_id.as_deref(), group.as_deref(), approve, check, target.as_deref(), lanes)
+    cmd::merge::run(store, task_id.as_deref(), group.as_deref(), approve, check, force, target.as_deref(), lanes)
 }
 pub(super) fn respond(task_id: String, input: Option<String>, file: Option<String>) -> Result<()> {
     cmd::respond::run(&task_id, input.as_deref(), file.as_deref())

--- a/src/store_workgroups.rs
+++ b/src/store_workgroups.rs
@@ -41,34 +41,60 @@ impl Store {
     }
 
     pub fn delete_workgroup(&self, id: &str) -> Result<Option<usize>> {
-        let tagged_tasks = self.count_workgroup_tasks(id)?;
-        let deleted = self
-            .db()
-            .execute("DELETE FROM workgroups WHERE id = ?1", params![id])?;
+        let mut conn = self.db();
+        let tx = conn.transaction()?;
+        let tagged_tasks = Self::count_workgroup_tasks_in_tx(&tx, id)?;
+        let deleted = tx.execute("DELETE FROM workgroups WHERE id = ?1", params![id])?;
         if deleted == 0 {
             return Ok(None);
         }
-        let workspace_dir = crate::paths::workspace_dir(id)?;
-        let ws = workspace_dir.to_string_lossy();
-        if ws.starts_with("/tmp/aid-wg-") || ws.starts_with("/private/tmp/aid-wg-") {
-            let _ = std::fs::remove_dir_all(&workspace_dir);
-        } else {
-            aid_warn!(
-                "[aid] SAFETY: refusing to remove workspace '{}' — not under /tmp/aid-wg-*",
-                ws
-            );
-        }
+        tx.commit()?;
+        drop(conn);
+        remove_workspace_dir(id)?;
         Ok(Some(tagged_tasks))
     }
 
-    fn count_workgroup_tasks(&self, id: &str) -> Result<usize> {
-        let count = self.db().query_row(
+    pub fn delete_workgroup_cascade(&self, id: &str) -> Result<Option<usize>> {
+        let mut conn = self.db();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM events
+             WHERE task_id IN (SELECT id FROM tasks WHERE workgroup_id = ?1)",
+            params![id],
+        )?;
+        let deleted_tasks = tx.execute("DELETE FROM tasks WHERE workgroup_id = ?1", params![id])?;
+        let deleted = tx.execute("DELETE FROM workgroups WHERE id = ?1", params![id])?;
+        if deleted == 0 {
+            return Ok(None);
+        }
+        tx.commit()?;
+        drop(conn);
+        remove_workspace_dir(id)?;
+        Ok(Some(deleted_tasks))
+    }
+
+    fn count_workgroup_tasks_in_tx(tx: &rusqlite::Transaction<'_>, id: &str) -> Result<usize> {
+        let count = tx.query_row(
             "SELECT COUNT(*) FROM tasks WHERE workgroup_id = ?1",
             params![id],
             |row| row.get::<_, i64>(0),
         )?;
         Ok(count as usize)
     }
+}
+
+fn remove_workspace_dir(id: &str) -> Result<()> {
+    let workspace_dir = crate::paths::workspace_dir(id)?;
+    let ws = workspace_dir.to_string_lossy();
+    if ws.starts_with("/tmp/aid-wg-") || ws.starts_with("/private/tmp/aid-wg-") {
+        let _ = std::fs::remove_dir_all(&workspace_dir);
+    } else {
+        aid_warn!(
+            "[aid] SAFETY: refusing to remove workspace '{}' — not under /tmp/aid-wg-*",
+            ws
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -152,6 +178,35 @@ mod tests {
 
         assert_eq!(tagged_tasks, Some(1));
         assert_eq!(task.workgroup_id.as_deref(), Some(workgroup.id.as_str()));
+        assert!(store
+            .get_workgroup(workgroup.id.as_str())
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn delete_workgroup_cascade_removes_group_tasks_and_events() {
+        let store = Store::open_memory().unwrap();
+        let workgroup = store
+            .create_workgroup("dispatch", "Shared repo rules.", None, None)
+            .unwrap();
+        store
+            .insert_task(&make_task("t-1001", workgroup.id.as_str()))
+            .unwrap();
+        store
+            .insert_event(&crate::types::TaskEvent {
+                task_id: crate::types::TaskId("t-1001".to_string()),
+                timestamp: Local::now(),
+                event_kind: crate::types::EventKind::Milestone,
+                detail: "deleted with task".to_string(),
+                metadata: None,
+            })
+            .unwrap();
+
+        let deleted_tasks = store.delete_workgroup_cascade(workgroup.id.as_str()).unwrap();
+
+        assert_eq!(deleted_tasks, Some(1));
+        assert!(store.get_task("t-1001").unwrap().is_none());
         assert!(store
             .get_workgroup(workgroup.id.as_str())
             .unwrap()

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -235,7 +235,7 @@ pub async fn retry_task(
 }
 
 pub async fn merge_task(Path(id): Path<String>, State(store): State<Arc<Store>>) -> impl IntoResponse {
-    match crate::cmd::merge::run(store, Some(&id), None, true, false, None, false) {
+    match crate::cmd::merge::run(store, Some(&id), None, true, false, false, None, false) {
         Ok(()) => (StatusCode::OK, Json(ActionResponse { ok: true, new_task_id: None, error: None })).into_response(),
         Err(error) => action_error(error).into_response(),
     }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -331,7 +331,9 @@ fn group_update_and_delete_work() {
     assert!(delete_output.status.success());
     let delete_stdout = String::from_utf8_lossy(&delete_output.stdout);
     assert!(delete_stdout.contains("deleted"));
-    assert!(delete_stdout.contains("Historical tasks still tagged: 0"));
+    assert!(delete_stdout.contains(
+        "Historical tasks still tagged: 0 — use --cascade to also delete them"
+    ));
 
     let list_output = aid_cmd_in(temp_dir.path())
         .args(["group", "list"])


### PR DESCRIPTION
## Summary

Ports 4 independent UX features that were committed on a stale `gitbutler/workspace` branch (49 commits behind origin/main) but never made it to `main`. Origin has since released through v8.93.0 with its own direction on several other items in the same batch (board anti-poll, lock PID check, zombie reaper, `clean --worktrees` repo-scope) — those are **skipped** because origin has its own implementation (via auto-gc + doctor).

### What landed here

| Feature | Source SHA | Conflict resolution |
|---------|-----------|---------------------|
| GH#89 background agent binary preflight | `bb4059f` | `agent/mod.rs` Qwen arm added; `background.rs` keeps both `rescue_files_summary` + new helpers; `run_dispatch.rs` switched to shared `agent::ensure_agent_binary_available` helper |
| `aid merge --force` for FAIL tasks | `8386e26` | Mechanical `merge_single`/`run` test call-site updates for new `force: bool` param |
| `aid group delete --cascade` | `edd02db` | Clean cherry-pick |
| batch TOML `dir = "."` resolves relative to the TOML file | `13e5e75` | Clean cherry-pick |

Plus one fixup: `background_binary_tests` struct literal gets `setup`, `link_deps`, `pre_task_dirty_paths` fields that were added on origin after the stale commit.

### Verification

- `cargo check --all-targets` PASS
- Merge commits preserved per-feature for bisectability

### Not in this PR

- A+B `aid reply` / `aid unstick` feature stack (6+ commits, ~2000 LOC) — filed as follow-up.
- Issue #105 (aid batch + GitButler merge-back UX) — separate.

## Test plan

- [ ] cargo test on PR branch
- [ ] Smoke: \`aid merge --force\` on a FAIL task
- [ ] Smoke: \`aid group delete --cascade <wg>\`
- [ ] Smoke: \`aid batch <toml-with-dir-dot>\` resolves relative to TOML
- [ ] Smoke: background dispatch with missing agent binary fails fast with clear error