### PR TITLE
docs: refresh roadmap + ux-debt after v8.94.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,18 +4,16 @@ Snapshot of where the project is heading. Maintained by hand; authoritative back
 
 ## Current state
 
-- Released on origin: **v8.92.0** — fix(verify): detect declared-but-unadded new files.
-- Unreleased on `gitbutler/workspace`: 14 merge commits (A+B reply/unstick, GH#89 bg preflight, release orphan-check, 6 UX hotfixes). **Not on origin/main**. See `ai-board` item `wi-273e` for port plan.
+- Released on origin: **v8.94.0** (2026-04-20) — A+B reply/unstick full port, `aid merge --force`, `aid group delete --cascade`, batch `dir = "."` resolve, GH#89 bg preflight, issue #105 GitButler batch UX (auto-prune worktrees, merge-back hint, detect-and-prompt, `docs/gitbutler.md`), 28-lint clippy cleanup that unblocked CI after 5+ red releases.
+- No stale unreleased work — `gitbutler/workspace` is fully caught up with origin via port PRs #106, #107, #108, #109, #110. `ai-board` item `wi-273e` is done.
 
-## Near-term (next release, v8.93-ish)
+## Near-term (next release cycle)
 
-**Goal**: port today's work onto origin/main and cut a release.
+**Goals**:
 
-- Port A+B reply/unstick (message_queries, IdleDetector, pty consumption, TaskStatus::Stalled).
-- Port GH#89 background-path agent binary preflight.
-- Port `scripts/release.sh` orphan-branch + orphan-worktree hygiene check.
-- Port `aid merge --force`, `aid group delete --cascade`, `aid batch dir="."` resolve, docs/ux-debt.md.
-- **Skip** (origin has different direction already): board anti-poll relaxation, lock PID check (origin's `aid doctor` / `aid_gc auto` handles same class), zombie reaper, clean --worktrees repo-scope.
+1. **Tidy up commit-message hygiene.** Several v8.94.0 port PRs landed with auto-generated "task N" commit messages from a Claude Code hook. Investigate the post-Stop / PostToolUse hook that generates those and either write meaningful messages or disable it during release flows.
+2. **Promote `DetectAgentsGuard` and `workspace_dir` override to production.** Both are test-only today; the same pattern (thread-local guards for "expensive discovery" logic) could give dispatch code a similar fast-path for `--sandbox` / CI usage.
+3. **Clippy gate in `release.sh`.** Now that CI runs clippy green, make `scripts/release.sh` also run `cargo clippy --all-targets -- -D warnings` as a pre-release check so we don't regress quietly between rust minor-version bumps.
 
 ## v9.0 — UX overhaul (semver major)
 
@@ -35,7 +33,7 @@ Systemic cleanup of the 14 debt items in [`docs/ux-debt.md`](./ux-debt.md). Trac
 
 ## v9.x — deferred ideas
 
-- **C: non-PTY agent message support** — original A+B+C plan had C for API/background agents (not just PTY). Requires agent-side polling hook or message-aware tick. Reopen after v9.0 lands.
+- **C: non-PTY agent message support** — original A+B+C plan had C for API/background agents (not just PTY). A and B shipped in v8.94.0; C requires agent-side polling hook or message-aware tick. Reopen after v9.0 lands.
 - **Batch resume by content hash** — `aid batch foo.toml` detects existing workgroup with matching content, offers resume. Kills the "49 zombie rows from 7 failed dispatches" class of UX bug.
 - **Session-preflight** — already shipped as a per-repo script + Claude Code SessionStart hook (`scripts/session-preflight.sh`, `.claude/settings.json`). Not yet promoted to user-level (`~/.claude/settings.json`) for all repos. Candidate for v9.x once the per-repo version proves stable.
 

--- a/docs/ux-debt.md
+++ b/docs/ux-debt.md
@@ -4,6 +4,28 @@ Systemic UX issues observed via dogfooding. Sorted by severity within category. 
 
 ---
 
+## Fixed in v8.94.0 (latest)
+
+### GitButler batch merge-back (issue #105)
+
+- **Aid worktrees leaked after batch completion, blocking `but apply`** — successful tasks now auto-prune their aid-owned worktree. Failed and shared worktrees preserved. Opt-out: `.aid/project.toml` → `keep_worktrees_after_done = true`.
+- **`aid merge --lanes` was undiscoverable on GitButler repos** — `aid batch` completion + `aid watch --quiet --group` now print the lane merge-back hint when GitButler integration is active.
+- **First `aid batch` on a GitButler repo without project.toml config required manual wiring** — batch now offers a one-time enable prompt. `--yes` / `--no-prompt` skip silently; declining writes a `suppress_gitbutler_prompt = true` marker.
+- **No end-to-end docs for `aid` + GitButler workflow** — new `docs/gitbutler.md` covers modes, batch→review→merge pipeline, `AID_GITBUTLER=0` escape hatch, troubleshooting, `keep_worktrees_after_done` knob.
+
+### A+B steer / reply / unstick (port completion)
+
+- **`aid steer` was fire-and-forget** — now delegates to persisted `aid reply` path: new `task_messages` table, delivery tracking, ack on first output-after-delivery.
+- **No way to detect or recover hung tasks** — new `aid unstick <task-id>` command + `TaskStatus::Stalled` variant + `IdleDetector` policy with auto-nudge-then-escalate thresholds wired into the PTY monitor.
+
+### CI / release reliability
+
+- **Flaky `workspace_dir` test isolation** — `/tmp/aid-wg-{id}` was hardcoded, so parallel tests sharing workgroup IDs raced on shared filesystem paths. Now test-isolated via `AidHomeGuard` (production behavior unchanged).
+- **Fallback tests failed in CI where no agent binaries are on PATH** — new `DetectAgentsGuard` pins `detect_agents()` return value per-thread under `cfg(test)`.
+- **28 pre-existing clippy `-D warnings` lints** (rust-1.93 + rust-1.95 strictness) blocked CI for 5+ releases — all mechanical rewrites, no behavior change. CI's build job is green again.
+
+---
+
 ## Fixed in v8.85 (this release cycle)
 
 ### Batch / dispatch


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the v8.94.0 release (tag pushed, 77e3744 on main).

- \`docs/roadmap.md\` — current state bumped from v8.92.0 to v8.94.0; the "port the stale gitbutler/workspace work" goal is now done. Near-term section re-pointed at three lower-priority follow-ups (commit-message hygiene for the \"task N\" auto-commit hook, promoting \`DetectAgentsGuard\` / \`workspace_dir\` test guards to production, and a clippy gate in \`release.sh\`).
- \`docs/ux-debt.md\` — new "Fixed in v8.94.0 (latest)" section at the top covering:
  - Issue #105's four GitButler batch friction points (worktree auto-prune, merge-back hint, detect-and-prompt, \`docs/gitbutler.md\`)
  - A+B port completion (persisted \`aid reply\`, \`aid unstick\`, \`TaskStatus::Stalled\`, \`IdleDetector\`)
  - CI / release reliability (workspace_dir test isolation, \`DetectAgentsGuard\`, 28 clippy lints cleared)

No code changes; no CHANGELOG bump (v8.94.0 already landed).

## Test plan

- [ ] Read both files on GitHub, confirm sections render.