### PR TITLE
fix(worktree): protect active worktrees from prune + expose --json/--active (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,17 @@ WT=$(aid worktree create feat/my-feature)
 aid run codex "Implement feature" --dir $WT
 aid run codex "Add tests" --dir $WT
 aid worktree list
+aid worktree list --json
+aid worktree list --active
 aid worktree remove feat/my-feature
 
 # Automatic worktree (created per-task)
 aid run codex "Implement feature" --worktree feat/my-feature --dir .
 ```
+
+`aid worktree list --json` emits machine-readable worktree state for cleanup tools, including path, branch, active lock status, lock pid/task ID, and directory mtime age. Use `aid worktree list --active` to show only worktrees whose `.aid-lock` contains a live task pid.
+
+Aid writes `.aid-lock` at task start with `pid=...` and `task=t-...`, then removes it on completion. External cleanup tools should refuse to delete a worktree when that lock's pid is still alive.
 
 `aid merge` auto-merges the worktree branch into the current branch and cleans up the worktree directory. Failed tasks auto-cleanup their worktrees. Worktree escape detection warns if an agent accidentally modifies the main repo.
 

--- a/src/cli_actions.rs
+++ b/src/cli_actions.rs
@@ -271,6 +271,12 @@ pub enum WorktreeAction {
     },
     /// List active aid-managed worktrees
     List {
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+        /// Show only worktrees with live task locks
+        #[arg(long)]
+        active: bool,
         /// Repository path (defaults to current dir)
         #[arg(long)]
         repo: Option<String>,

--- a/src/cmd/worktree.rs
+++ b/src/cmd/worktree.rs
@@ -3,10 +3,26 @@
 // Deps: crate::worktree
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::path::Path;
 use std::time::SystemTime;
 
 const STALE_WORKTREE_AGE_SECS: u64 = 24 * 60 * 60;
+
+#[derive(Serialize)]
+struct AidWorktreeEntry {
+    path: String,
+    branch: String,
+    active: bool,
+    lock_pid: Option<u32>,
+    lock_task_id: Option<String>,
+    modified_age_secs: u64,
+}
+
+struct WorktreeLock {
+    pid: u32,
+    task_id: Option<String>,
+}
 
 /// Check if a path is an aid-managed worktree (delegates to shared sandbox guard).
 fn is_aid_worktree(path: &str) -> bool {
@@ -28,11 +44,16 @@ pub fn create(branch: &str, base: Option<&str>, repo: Option<&str>) -> Result<()
 }
 
 /// List all aid-managed worktrees (~/.aid/worktrees/* plus legacy /tmp/aid-wt-*).
-pub fn list(repo: Option<&str>) -> Result<()> {
+pub fn list(repo: Option<&str>, json: bool, active_only: bool) -> Result<()> {
     let repo_dir = repo.unwrap_or(".");
+    if json {
+        println!("{}", list_json(Some(repo_dir), active_only)?);
+        return Ok(());
+    }
+    let entries = filtered_worktree_entries(repo_dir, active_only)?;
     let mut count = 0;
-    for (path, branch) in aid_worktree_entries(repo_dir)? {
-        println!("{:<50} {}", path, branch);
+    for entry in entries {
+        println!("{:<50} {}", entry.path, entry.branch);
         count += 1;
     }
     if count == 0 {
@@ -48,20 +69,35 @@ pub fn prune(repo: Option<&str>) -> Result<()> {
     let entries = aid_worktree_entries(repo_dir)?;
     // First pass: clear stale locks on ALL worktrees (not just old ones)
     let mut locks_cleared = 0usize;
-    for (path, _) in &entries {
-        if clear_dead_lock(Path::new(path)) {
+    for entry in &entries {
+        if clear_dead_lock(Path::new(&entry.path)) {
             locks_cleared += 1;
         }
     }
     // Second pass: remove worktrees older than 24h
     let mut pruned = 0usize;
-    for path in stale_worktree_paths(repo_dir)? {
-        match super::merge::remove_worktree(repo_dir, &path) {
+    for entry in aid_worktree_entries(repo_dir)? {
+        if let Some(lock) = live_worktree_lock(Path::new(&entry.path)) {
+            if is_stale_worktree_path(Path::new(&entry.path)) {
+                let task = lock.task_id.as_deref().unwrap_or("unknown");
+                aid_warn!(
+                    "[aid] Skipping prune: {} has active task {} (pid {})",
+                    entry.path,
+                    task,
+                    lock.pid
+                );
+            }
+            continue;
+        }
+        if !should_prune_worktree(&entry.path) {
+            continue;
+        }
+        match super::merge::remove_worktree(repo_dir, &entry.path) {
             Ok(()) => {
-                println!("[aid] Pruned stale worktree: {path}");
+                println!("[aid] Pruned stale worktree: {}", entry.path);
                 pruned += 1;
             }
-            Err(err) => aid_warn!("[aid] Failed to prune {path}: {err}"),
+            Err(err) => aid_warn!("[aid] Failed to prune {}: {err}", entry.path),
         }
     }
     if pruned == 0 && locks_cleared == 0 {
@@ -99,12 +135,24 @@ pub fn remove(branch: &str, repo: Option<&str>) -> Result<()> {
 fn stale_worktree_paths(repo_dir: &str) -> Result<Vec<String>> {
     Ok(aid_worktree_entries(repo_dir)?
         .into_iter()
-        .map(|(path, _branch)| path)
+        .map(|entry| entry.path)
         .filter(|path| should_prune_worktree(path))
         .collect())
 }
 
-fn aid_worktree_entries(repo_dir: &str) -> Result<Vec<(String, String)>> {
+fn list_json(repo: Option<&str>, active_only: bool) -> Result<String> {
+    let entries = filtered_worktree_entries(repo.unwrap_or("."), active_only)?;
+    serde_json::to_string_pretty(&entries).map_err(Into::into)
+}
+
+fn filtered_worktree_entries(repo_dir: &str, active_only: bool) -> Result<Vec<AidWorktreeEntry>> {
+    Ok(aid_worktree_entries(repo_dir)?
+        .into_iter()
+        .filter(|entry| !active_only || entry.active)
+        .collect())
+}
+
+fn aid_worktree_entries(repo_dir: &str) -> Result<Vec<AidWorktreeEntry>> {
     let output = std::process::Command::new("git")
         .args(["-C", repo_dir, "worktree", "list", "--porcelain"])
         .output()
@@ -131,45 +179,87 @@ fn aid_worktree_entries(repo_dir: &str) -> Result<Vec<(String, String)>> {
 }
 
 fn push_aid_worktree_entry(
-    entries: &mut Vec<(String, String)>,
+    entries: &mut Vec<AidWorktreeEntry>,
     current_path: &mut String,
     current_branch: &mut String,
 ) {
     if is_aid_worktree(current_path) && !current_path.is_empty() {
-        entries.push((current_path.clone(), current_branch.clone()));
+        entries.push(aid_worktree_entry(current_path, current_branch));
     }
     current_path.clear();
     current_branch.clear();
 }
 
+fn aid_worktree_entry(path: &str, branch: &str) -> AidWorktreeEntry {
+    let lock = live_worktree_lock(Path::new(path));
+    AidWorktreeEntry {
+        path: path.to_string(),
+        branch: branch.to_string(),
+        active: lock.is_some(),
+        lock_pid: lock.as_ref().map(|lock| lock.pid),
+        lock_task_id: lock.and_then(|lock| lock.task_id),
+        modified_age_secs: modified_age_secs(Path::new(path)),
+    }
+}
+
+fn read_worktree_lock(wt_path: &Path) -> Option<WorktreeLock> {
+    let content = std::fs::read_to_string(wt_path.join(".aid-lock")).ok()?;
+    let mut pid = None;
+    let mut task_id = None;
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("pid=") {
+            pid = value.trim().parse::<u32>().ok();
+        } else if let Some(value) = line.strip_prefix("task=") {
+            task_id = Some(value.trim().to_string());
+        }
+    }
+    Some(WorktreeLock { pid: pid?, task_id })
+}
+
+fn live_worktree_lock(wt_path: &Path) -> Option<WorktreeLock> {
+    let lock = read_worktree_lock(wt_path)?;
+    crate::worktree::process_alive_check(lock.pid).then_some(lock)
+}
+
 /// Clear a .aid-lock file if the holding process is dead. Returns true if cleared.
 fn clear_dead_lock(wt_path: &Path) -> bool {
-    let lock_path = wt_path.join(".aid-lock");
-    let content = match std::fs::read_to_string(&lock_path) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let pid = content.lines()
-        .find_map(|line| line.strip_prefix("pid="))
-        .and_then(|p| p.trim().parse::<u32>().ok());
-    let Some(pid) = pid else { return false };
-    if crate::worktree::process_alive_check(pid) {
+    let Some(lock) = read_worktree_lock(wt_path) else { return false };
+    if crate::worktree::process_alive_check(lock.pid) {
         return false;
     }
-    let task = content.lines()
-        .find_map(|line| line.strip_prefix("task="))
-        .unwrap_or("unknown");
-    println!("[aid] Cleared stale lock in {} (task={}, pid={} dead)", wt_path.display(), task, pid);
-    let _ = std::fs::remove_file(&lock_path);
+    let task = lock.task_id.as_deref().unwrap_or("unknown");
+    println!(
+        "[aid] Cleared stale lock in {} (task={}, pid={} dead)",
+        wt_path.display(),
+        task,
+        lock.pid
+    );
+    let _ = std::fs::remove_file(wt_path.join(".aid-lock"));
     true
 }
 
 fn should_prune_worktree(wt_path: &str) -> bool {
+    if live_worktree_lock(Path::new(wt_path)).is_some() {
+        return false;
+    }
+    is_stale_worktree_path(Path::new(wt_path))
+}
+
+fn is_stale_worktree_path(wt_path: &Path) -> bool {
     std::fs::metadata(wt_path)
         .ok()
         .and_then(|meta| meta.modified().ok())
         .map(is_stale_worktree_time)
         .unwrap_or(true)
+}
+
+fn modified_age_secs(wt_path: &Path) -> u64 {
+    std::fs::metadata(wt_path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .map(|age| age.as_secs())
+        .unwrap_or(0)
 }
 
 fn is_stale_worktree_time(modified: SystemTime) -> bool {
@@ -180,29 +270,5 @@ fn is_stale_worktree_time(modified: SystemTime) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::should_prune_worktree;
-    use std::process::Command;
-
-    #[test]
-    fn should_prune_worktree_old_path() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("aid-wt-old");
-        std::fs::create_dir(&path).expect("create dir");
-        let status = Command::new("touch")
-            .args(["-t", "202001010000"])
-            .arg(&path)
-            .status()
-            .expect("touch status");
-        assert!(status.success());
-        assert!(should_prune_worktree(path.to_str().expect("utf8 path")));
-    }
-
-    #[test]
-    fn should_prune_worktree_recent_path() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("aid-wt-recent");
-        std::fs::create_dir(&path).expect("create dir");
-        assert!(!should_prune_worktree(path.to_str().expect("utf8 path")));
-    }
-}
+#[path = "worktree/tests.rs"]
+mod tests;

--- a/src/cmd/worktree/tests.rs
+++ b/src/cmd/worktree/tests.rs
@@ -1,0 +1,171 @@
+// Tests for `aid worktree` list/prune lock behavior.
+// Covers live-lock pruning protection, dead-lock cleanup, and JSON listing shape.
+// Deps: super command helpers, git CLI, tempfile.
+
+use super::{list_json, prune, should_prune_worktree};
+use crate::test_subprocess;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn git(repo_dir: &Path, args: &[&str]) {
+    assert!(Command::new("git")
+        .args(["-C", &repo_dir.to_string_lossy()])
+        .args(args)
+        .status()
+        .unwrap()
+        .success());
+}
+
+fn init_repo(repo_dir: &Path) {
+    git(repo_dir, &["init", "-b", "main"]);
+    git(repo_dir, &["config", "user.email", "test@example.com"]);
+    git(repo_dir, &["config", "user.name", "Test User"]);
+    std::fs::write(repo_dir.join("file.txt"), "hello\n").unwrap();
+    git(repo_dir, &["add", "file.txt"]);
+    git(repo_dir, &["commit", "-m", "init"]);
+}
+
+fn legacy_path(name: &str) -> PathBuf {
+    Path::new("/tmp").join(format!("aid-wt-{}-{name}", std::process::id()))
+}
+
+fn add_worktree(repo_dir: &Path, branch: &str, name: &str) -> PathBuf {
+    let path = legacy_path(name);
+    let _ = std::fs::remove_dir_all(&path);
+    git(
+        repo_dir,
+        &[
+            "worktree",
+            "add",
+            &path.to_string_lossy(),
+            "-b",
+            branch,
+        ],
+    );
+    path
+}
+
+fn remove_worktree(repo_dir: &Path, path: &Path) {
+    let _ = Command::new("git")
+        .args(["-C", &repo_dir.to_string_lossy()])
+        .args(["worktree", "remove", "--force", &path.to_string_lossy()])
+        .status();
+    let _ = std::fs::remove_dir_all(path);
+}
+
+fn make_old(path: &Path) {
+    let status = Command::new("touch")
+        .args(["-t", "202001010000"])
+        .arg(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+fn entry_for_path<'a>(entries: &'a [Value], path: &Path) -> &'a Value {
+    let path = path.to_string_lossy();
+    entries
+        .iter()
+        .find(|entry| entry.get("path").and_then(Value::as_str) == Some(path.as_ref()))
+        .unwrap()
+}
+
+#[test]
+fn should_prune_worktree_old_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("aid-wt-old");
+    std::fs::create_dir(&path).unwrap();
+    make_old(&path);
+    assert!(should_prune_worktree(path.to_str().unwrap()));
+}
+
+#[test]
+fn should_prune_worktree_recent_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("aid-wt-recent");
+    std::fs::create_dir(&path).unwrap();
+    assert!(!should_prune_worktree(path.to_str().unwrap()));
+}
+
+#[test]
+fn prune_skips_worktree_with_live_lock() {
+    let _permit = test_subprocess::acquire();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    let wt = add_worktree(repo.path(), "feat/live-lock", "live-lock");
+    std::fs::write(
+        wt.join(".aid-lock"),
+        format!("pid={}\ntask=t-live\n", std::process::id()),
+    )
+    .unwrap();
+    make_old(&wt);
+
+    assert!(!should_prune_worktree(wt.to_str().unwrap()));
+    prune(Some(repo.path().to_str().unwrap())).unwrap();
+    assert!(wt.exists());
+    assert!(wt.join(".aid-lock").exists());
+
+    remove_worktree(repo.path(), &wt);
+}
+
+#[test]
+fn prune_clears_dead_lock_and_removes_old_worktree() {
+    let _permit = test_subprocess::acquire();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    let wt = add_worktree(repo.path(), "feat/dead-lock", "dead-lock");
+    std::fs::write(wt.join(".aid-lock"), "pid=999999999\ntask=t-dead\n").unwrap();
+    make_old(&wt);
+
+    assert!(should_prune_worktree(wt.to_str().unwrap()));
+    prune(Some(repo.path().to_str().unwrap())).unwrap();
+    assert!(!wt.exists());
+    assert!(!wt.join(".aid-lock").exists());
+}
+
+#[test]
+fn list_json_reports_active_and_inactive_worktrees() {
+    let _permit = test_subprocess::acquire();
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    let active = add_worktree(repo.path(), "feat/json-active", "json-active");
+    let inactive = add_worktree(repo.path(), "feat/json-inactive", "json-inactive");
+    let dead_locked = add_worktree(repo.path(), "feat/json-dead", "json-dead");
+    std::fs::write(
+        active.join(".aid-lock"),
+        format!("pid={}\ntask=t-json\n", std::process::id()),
+    )
+    .unwrap();
+    std::fs::write(dead_locked.join(".aid-lock"), "pid=999999999\ntask=t-dead\n").unwrap();
+
+    let json = list_json(Some(repo.path().to_str().unwrap()), false).unwrap();
+    let entries = serde_json::from_str::<Vec<Value>>(&json).unwrap();
+    let active_entry = entry_for_path(&entries, &active);
+    let inactive_entry = entry_for_path(&entries, &inactive);
+    let dead_entry = entry_for_path(&entries, &dead_locked);
+
+    assert_eq!(active_entry.get("branch").and_then(Value::as_str), Some("feat/json-active"));
+    assert_eq!(active_entry.get("active").and_then(Value::as_bool), Some(true));
+    assert_eq!(active_entry.get("lock_pid").and_then(Value::as_u64), Some(std::process::id() as u64));
+    assert_eq!(active_entry.get("lock_task_id").and_then(Value::as_str), Some("t-json"));
+    assert!(active_entry.get("modified_age_secs").and_then(Value::as_u64).is_some());
+    assert_eq!(inactive_entry.get("active").and_then(Value::as_bool), Some(false));
+    assert!(inactive_entry.get("lock_pid").is_some_and(Value::is_null));
+    assert!(inactive_entry.get("lock_task_id").is_some_and(Value::is_null));
+    assert_eq!(dead_entry.get("active").and_then(Value::as_bool), Some(false));
+    assert!(dead_entry.get("lock_pid").is_some_and(Value::is_null));
+    assert!(dead_entry.get("lock_task_id").is_some_and(Value::is_null));
+
+    let active_json = list_json(Some(repo.path().to_str().unwrap()), true).unwrap();
+    let active_only = serde_json::from_str::<Vec<Value>>(&active_json).unwrap();
+    assert_eq!(active_only.len(), 1);
+    assert_eq!(
+        active_only[0].get("path").and_then(Value::as_str),
+        Some(active.to_string_lossy().as_ref())
+    );
+
+    remove_worktree(repo.path(), &active);
+    remove_worktree(repo.path(), &inactive);
+    remove_worktree(repo.path(), &dead_locked);
+}

--- a/src/cmd_dispatch/handlers_b.rs
+++ b/src/cmd_dispatch/handlers_b.rs
@@ -205,7 +205,7 @@ fn group_finding(store: Arc<store::Store>, action: GroupFindingAction) -> Result
 pub(super) fn worktree(action: WorktreeAction) -> Result<()> {
     match action {
         WorktreeAction::Create { branch, base, repo } => cmd::worktree::create(&branch, base.as_deref(), repo.as_deref()),
-        WorktreeAction::List { repo } => cmd::worktree::list(repo.as_deref()),
+        WorktreeAction::List { repo, json, active } => cmd::worktree::list(repo.as_deref(), json, active),
         WorktreeAction::Prune { repo } => cmd::worktree::prune(repo.as_deref()),
         WorktreeAction::Remove { branch, repo } => cmd::worktree::remove(&branch, repo.as_deref()),
     }


### PR DESCRIPTION
## Summary
- Fixes #114. External tools (e.g. `tools/branch-audit.sh`) had no programmatic way to detect aid worktrees with running tasks, and `aid worktree prune` itself only checked age (>24h), not lock liveness. A long-running task in an old worktree could be pruned out from under itself, losing in-progress work.
- `aid worktree list --json` now emits per-worktree records with `path`, `branch`, `active`, `lock_pid`, `lock_task_id`, `modified_age_secs`. `--active` filters to live-locked worktrees only.
- `aid worktree prune` reads `.aid-lock` and skips any worktree whose pid is alive, regardless of age, with a warning.
- README documents the `.aid-lock` contract for external cleanup tools (`pid=...`, `task=t-...`; remove only if pid is dead).

## Audit
Cross-audited via codex (read-only). All 12 functional checks PASS after retry: JSON shape correct, `active` semantics tied to `process_alive_check`, prune skips live locks, dead locks still cleaned, plain output unchanged, `--active` filter correct, CLI wiring correct, no `unwrap()` in production, file/function within size limits, `cargo check --all-targets` clean, README accurate.

The retry added the missing dead-lock case to the JSON test matrix (was the only initial gap).

## Test plan
- [x] `cargo check --all-targets` clean
- [x] `cargo check --tests` clean (new tests compile)
- [ ] Manual: dispatch a task into a fresh worktree, run `aid worktree list --json` from a separate shell, confirm `active=true` + `lock_pid` matches the running task
- [ ] Manual: run `aid worktree prune` while a task is running, confirm the active worktree is skipped with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)