### PR TITLE
feat(byok): provider scaffolding for opencode custom-provider wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- feat(byok): add bash+jq BYOK provider scaffolding for opencode custom providers, including apply/probe/remove scripts, a MiMo example manifest, sandboxed script coverage, and user docs for routing OpenAI-compatible providers through generated aid custom agents.
+
+
 ## v8.99.1 (2026-04-28)
 - fix(commit): skip markdown bullets in rescue commit subject (#122, #123) — `extract_task_summary` now skips lines starting with `- `, `* `, `+ `, or `<digits>. ` in both the `[Task]`-section parser and the fallback loop. When neither pass yields a usable line, falls back to a generic `agent commit (task <task-id-short>)`. Previously, when a brief lacked an explicit `[Task]` header, the rescue commit subject would be the first injected `[Team Knowledge]` markdown bullet, truncated to 60 chars.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ An agent is a **non-interactive CLI** that accepts a prompt, performs the task a
 
 Built-in agents: `gemini`, `codex`, `copilot`, `opencode`, `cursor`, `kilo`, `codebuff`, `droid`, `oz`, `claude`. Custom agents can be added via `aid agent add` for any compatible CLI (e.g. `aider`). `aid` supports non-interactive CLI modes such as `claude -p` and `copilot -p`; interactive chat sessions can still orchestrate `aid`, but they are not required.
 
+For BYOK OpenAI-compatible providers routed through opencode custom-provider config, see [`docs/byok-pattern.md`](docs/byok-pattern.md).
+
 Examples:
 
 ```bash

--- a/docs/byok-pattern.md
+++ b/docs/byok-pattern.md
@@ -1,0 +1,228 @@
+<!--
+Purpose: Documents the BYOK custom-provider pattern for aid users.
+Exports: Manifest schema, apply/probe/remove workflows, and an ACME walkthrough.
+Dependencies: opencode custom providers, jq/python helper scripts in scripts/.
+-->
+
+# BYOK Provider Pattern
+
+The BYOK pattern lets `aid` route an `opencode` custom provider as a normal aid custom agent without modifying `opencode-go`, built-in providers, or Rust agent code. Each provider is described by a TOML manifest, then applied into:
+
+- `~/.config/opencode/opencode.json` under `provider.<id>`
+- `~/.local/share/opencode/auth.json` under `<id>`
+- `~/.aid/agents/<id>.toml` as an aid custom agent
+
+MiMo is the canonical real example. See `examples/byok/mimo.toml`; it uses `key_env = "MIMO_API_KEY"` and does not store the real API key in the repo.
+
+## Requirements
+
+The helper scripts require `bash`, `jq`, `python3` with stdlib `tomllib`, and `opencode` for non-dry-run apply/remove/probe flows.
+
+## Manifest Schema
+
+```toml
+# ~/.aid/byok/<id>.toml
+[byok]
+id = "acme"                                 # required, used as opencode provider key + aid agent id
+display_name = "ACME (corporate plan)"      # optional
+protocol = "openai"                         # required, MVP only supports "openai"
+base_url = "https://api.acme.example/v1"    # required
+key_env = "ACME_API_KEY"                    # optional, env var name
+api_key = "..."                             # optional, literal (discouraged; prefer key_env)
+default_model = "acme-pro"                  # required, used by generated aid agent
+timeout_ms = 300000                         # optional
+
+[[byok.model]]
+id = "acme-pro"                             # required
+name = "ACME Pro"                           # optional
+context = 131072                            # required
+output = 8192                               # required
+tool_call = true                            # default true
+reasoning = false                           # default false
+
+[[byok.model]]
+id = "acme-mini"
+context = 32768
+output = 4096
+
+[byok.capabilities]                         # optional, copied into generated aid agent TOML
+research = 5
+simple_edit = 6
+complex_impl = 5
+frontend = 4
+debugging = 5
+testing = 5
+refactoring = 5
+documentation = 5
+```
+
+Required fields are `id`, `protocol = "openai"`, `base_url`, `default_model`, and at least one `[[byok.model]]` with `id`, `context`, and `output`.
+
+API keys resolve in this order:
+
+1. `--key <api-key>` passed to `scripts/aid-byok-apply.sh` or `scripts/aid-byok-probe.sh`
+2. `[byok].api_key`
+3. Environment variable named by `[byok].key_env`
+
+Prefer `key_env` for checked-in manifests.
+
+## Apply Flow
+
+Run:
+
+```bash
+export ACME_API_KEY="..."
+bash scripts/aid-byok-apply.sh ~/.aid/byok/acme.toml
+```
+
+For inspection only:
+
+```bash
+bash scripts/aid-byok-apply.sh --dry-run examples/byok/mimo.toml
+```
+
+`apply` validates the manifest, resolves the API key, backs up both opencode JSON files with timestamped `.bak.<unix-ts>` files, and merges only the target provider:
+
+```jq
+.provider = (.provider // {}) | .provider[$id] = $block
+```
+
+That means existing siblings such as `provider.opencode`, `provider.opencode-go`, and unrelated custom providers are preserved. The script never replaces the whole `provider` object.
+
+The auth entry is added or replaced as:
+
+```json
+{"<id>": {"type": "api", "key": "..."}}
+```
+
+The auth file is written with mode `600`.
+
+After writing, `apply` runs `opencode models` and expects a model line beginning with `<id>/`. If verification fails, it restores the opencode config and auth backups and exits non-zero.
+
+All paths are overrideable for tests and sandboxes:
+
+```bash
+OPENCODE_CONFIG_DIR=/tmp/opencode-config \
+OPENCODE_AUTH_DIR=/tmp/opencode-auth \
+AID_HOME=/tmp/aid \
+bash scripts/aid-byok-apply.sh ~/.aid/byok/acme.toml
+```
+
+## Generated Aid Agent
+
+`apply` writes `~/.aid/agents/<id>.toml` with a marker comment:
+
+```toml
+# aid-byok-generated: acme
+[agent]
+id = "acme"
+display_name = "ACME (corporate plan)"
+command = "bash"
+prompt_mode = "arg"
+fixed_args = ["-lc", "exec opencode run --model acme/acme-pro \"$@\"", "aid-byok-acme"]
+trust_tier = "api"
+```
+
+When aid dispatches this custom agent, the user prompt is passed through the bash wrapper to:
+
+```bash
+opencode run --model acme/acme-pro "<prompt>"
+```
+
+The `<id>/<default_model>` model id is what keeps routing explicit per call.
+
+If `[byok.capabilities]` is present, those scores are copied to `[agent.capabilities]` so the generated agent can participate in aid selection using the existing custom-agent surface.
+
+If `~/.aid/agents/<id>.toml` already exists without the generated marker, `apply` refuses to overwrite it.
+
+## Add A New Provider
+
+1. Create a manifest:
+
+```bash
+mkdir -p ~/.aid/byok
+cat > ~/.aid/byok/acme.toml <<'EOF'
+[byok]
+id = "acme"
+display_name = "ACME (corporate plan)"
+protocol = "openai"
+base_url = "https://api.acme.example/v1"
+key_env = "ACME_API_KEY"
+default_model = "acme-pro"
+timeout_ms = 300000
+
+[[byok.model]]
+id = "acme-pro"
+name = "ACME Pro"
+context = 131072
+output = 8192
+tool_call = true
+reasoning = false
+
+[[byok.model]]
+id = "acme-mini"
+context = 32768
+output = 4096
+
+[byok.capabilities]
+research = 5
+simple_edit = 6
+complex_impl = 5
+frontend = 4
+debugging = 5
+testing = 5
+refactoring = 5
+documentation = 5
+EOF
+```
+
+2. Export the key and inspect the planned changes:
+
+```bash
+export ACME_API_KEY="sk-..."
+bash scripts/aid-byok-apply.sh --dry-run ~/.aid/byok/acme.toml
+```
+
+3. Apply the provider:
+
+```bash
+bash scripts/aid-byok-apply.sh ~/.aid/byok/acme.toml
+```
+
+4. Probe tool-call support:
+
+```bash
+bash scripts/aid-byok-probe.sh ~/.aid/byok/acme.toml
+```
+
+The probe calls `/chat/completions` with a dummy `get_weather(city)` tool and reports `tool_calls: yes/no`, `finish_reason`, and a one-line content preview. It exits `0` when tool calls are present and `2` otherwise.
+
+5. Use the generated aid agent:
+
+```bash
+aid run acme "Summarize the retry flow in this repo" --dir .
+```
+
+## Coexistence
+
+BYOK providers coexist with built-in opencode subscriptions and other custom providers. Authentication stays isolated by provider id in `auth.json`; config stays isolated under `provider.<id>` in `opencode.json`.
+
+Routing is per call by model id. `opencode run --model acme/acme-pro` uses ACME, while `opencode run --model opencode/...` or `opencode-go/...` continues using those existing providers.
+
+## Remove Flow
+
+Remove by manifest path:
+
+```bash
+bash scripts/aid-byok-remove.sh ~/.aid/byok/acme.toml
+```
+
+Or remove by provider id:
+
+```bash
+bash scripts/aid-byok-remove.sh acme
+```
+
+`remove` backs up opencode config and auth files, deletes only `provider.<id>`, removes only the auth entry named `<id>`, and deletes `~/.aid/agents/<id>.toml` only when the file contains the `# aid-byok-generated: <id>` marker. Hand-written agent files are left in place.
+
+After deletion, `remove` runs `opencode models` and fails if any line still begins with `<id>/`.

--- a/examples/byok/mimo.toml
+++ b/examples/byok/mimo.toml
@@ -1,0 +1,38 @@
+# Example BYOK manifest for the official Xiaomi MiMo OpenAI-compatible endpoint.
+# Used by scripts/aid-byok-apply.sh to configure opencode and generate an aid agent.
+# Dependencies: opencode custom providers, MIMO_API_KEY environment variable.
+
+[byok]
+id = "mimo"
+display_name = "MiMo (Xiaomi official)"
+protocol = "openai"
+base_url = "https://token-plan-sgp.xiaomimimo.com/v1"
+key_env = "MIMO_API_KEY"
+default_model = "mimo-v2.5-pro"
+timeout_ms = 300000
+
+[[byok.model]]
+id = "mimo-v2.5-pro"
+name = "MiMo v2.5 Pro"
+context = 131072
+output = 8192
+tool_call = true
+reasoning = false
+
+[[byok.model]]
+id = "mimo-v2.5"
+name = "MiMo v2.5"
+context = 131072
+output = 8192
+tool_call = true
+reasoning = false
+
+[byok.capabilities]
+research = 5
+simple_edit = 6
+complex_impl = 5
+frontend = 4
+debugging = 5
+testing = 5
+refactoring = 5
+documentation = 5

--- a/scripts/aid-byok-apply.sh
+++ b/scripts/aid-byok-apply.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Applies an aid BYOK manifest to opencode custom-provider config.
+# Generates the matching aid custom-agent TOML and verifies the provider model list.
+# Dependencies: bash, jq, opencode, grep, date, mktemp, mkdir, cp, mv, cmp, chmod.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/aid-byok-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/aid-byok-apply.sh [--dry-run] [--key <api-key>] <manifest.toml>
+
+Environment overrides:
+  OPENCODE_CONFIG_DIR  Defaults to ~/.config/opencode
+  OPENCODE_AUTH_DIR    Defaults to ~/.local/share/opencode
+  AID_HOME             Defaults to ~/.aid
+EOF
+}
+
+restore_from_backups() {
+  local config_backup="$1"
+  local auth_backup="$2"
+  local agent_backup="$3"
+  local agent_path="$4"
+  local agent_existed="$5"
+  if [[ -n "${config_backup}" ]]; then
+    cp "${config_backup}" "$(byok_config_dir)/opencode.json"
+  fi
+  if [[ -n "${auth_backup}" ]]; then
+    cp "${auth_backup}" "$(byok_auth_dir)/auth.json"
+    chmod 600 "$(byok_auth_dir)/auth.json"
+  fi
+  if [[ -n "${agent_backup}" && -f "${agent_backup}" ]]; then
+    cp "${agent_backup}" "${agent_path}"
+  elif [[ "${agent_existed}" != "true" ]]; then
+    rm -f "${agent_path}"
+  fi
+}
+
+replace_file_if_changed() {
+  local path="$1"
+  local tmp="$2"
+  local ts="$3"
+  local mode="${4:-}"
+  local backup=""
+  if [[ -f "${path}" ]] && cmp -s "${path}" "${tmp}"; then
+    rm -f "${tmp}"
+    printf '\n'
+    return 0
+  fi
+  if [[ -f "${path}" ]]; then
+    backup="$(backup_file "${path}" "${ts}")"
+  fi
+  mv "${tmp}" "${path}"
+  if [[ -n "${mode}" ]]; then
+    chmod "${mode}" "${path}"
+  fi
+  printf '%s\n' "${backup}"
+}
+
+print_plan() {
+  local manifest_data="$1"
+  local key_source="$2"
+  local id default_model config_path auth_path agent_path
+  id="$(jq -r '.id' <<< "${manifest_data}")"
+  default_model="$(jq -r '.default_model' <<< "${manifest_data}")"
+  config_path="$(byok_config_dir)/opencode.json"
+  auth_path="$(byok_auth_dir)/auth.json"
+  agent_path="$(byok_aid_home)/agents/${id}.toml"
+
+  printf 'BYOK apply plan\n'
+  printf '  provider: %s\n' "${id}"
+  printf '  protocol: openai\n'
+  printf '  model: %s/%s\n' "${id}" "${default_model}"
+  printf '  key source: %s\n' "${key_source}"
+  printf '  opencode config: %s\n' "${config_path}"
+  printf '  opencode auth: %s\n' "${auth_path}"
+  printf '  aid agent: %s\n' "${agent_path}"
+  jq -r '.model[] | "  provider model: \(.id) context=\(.context) output=\(.output)"' <<< "${manifest_data}"
+}
+
+parse_args() {
+  dry_run="false"
+  flag_key=""
+  manifest=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        dry_run="true"
+        shift
+        ;;
+      --key)
+        [[ $# -ge 2 ]] || fail "--key requires a value"
+        flag_key="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --*)
+        fail "unknown option: $1"
+        ;;
+      *)
+        [[ -z "${manifest}" ]] || fail "only one manifest path is supported"
+        manifest="$1"
+        shift
+        ;;
+    esac
+  done
+  [[ -n "${manifest}" ]] || fail "missing manifest path"
+}
+
+apply_manifest() {
+  local manifest_data="$1"
+  local api_key="$2"
+  local id config_path auth_path agent_dir agent_path ts
+  local config_backup auth_backup agent_backup provider config_tmp auth_tmp agent_tmp pattern
+  local agent_existed="false"
+  id="$(jq -r '.id' <<< "${manifest_data}")"
+  config_path="$(byok_config_dir)/opencode.json"
+  auth_path="$(byok_auth_dir)/auth.json"
+  agent_dir="$(byok_aid_home)/agents"
+  agent_path="${agent_dir}/${id}.toml"
+  ts="$(date +%s)"
+
+  ensure_json_file "${config_path}"
+  ensure_json_file "${auth_path}"
+  mkdir -p "${agent_dir}"
+  if [[ -f "${agent_path}" ]] && ! grep -Fqx "# aid-byok-generated: ${id}" "${agent_path}"; then
+    fail "refusing to overwrite non-generated aid agent: ${agent_path}"
+  fi
+  if [[ -f "${agent_path}" ]]; then
+    agent_existed="true"
+  fi
+
+  provider="$(provider_block_json "${manifest_data}")"
+  config_tmp="$(mktemp "${TMPDIR:-/tmp}/aid-byok-config.XXXXXX")"
+  jq --arg id "${id}" --argjson block "${provider}" \
+    '.provider = (.provider // {}) | .provider[$id] = $block' \
+    "${config_path}" > "${config_tmp}"
+
+  auth_tmp="$(mktemp "${TMPDIR:-/tmp}/aid-byok-auth.XXXXXX")"
+  jq --arg id "${id}" --arg key "${api_key}" \
+    '.[$id] = {type: "api", key: $key}' \
+    "${auth_path}" > "${auth_tmp}"
+
+  agent_tmp="$(mktemp "${TMPDIR:-/tmp}/aid-byok-agent.XXXXXX")"
+  write_agent_toml "${manifest_data}" "${agent_tmp}"
+
+  config_backup="$(replace_file_if_changed "${config_path}" "${config_tmp}" "${ts}")"
+  auth_backup="$(replace_file_if_changed "${auth_path}" "${auth_tmp}" "${ts}" 600)"
+  agent_backup="$(replace_file_if_changed "${agent_path}" "${agent_tmp}" "${ts}")"
+
+  pattern="^${id//./\\.}/"
+  if ! opencode models | grep -E "${pattern}" >/dev/null; then
+    restore_from_backups "${config_backup}" "${auth_backup}" "${agent_backup}" "${agent_path}" "${agent_existed}"
+    fail "opencode did not list models for provider ${id}; restored backups"
+  fi
+
+  printf 'BYOK provider applied: %s\n' "${id}"
+}
+
+main() {
+  require_cmd jq
+  parse_args "$@"
+  local manifest_data resolved key_source api_key
+  manifest_data="$(manifest_json "${manifest}")"
+  validate_manifest "${manifest_data}"
+  resolved="$(resolve_api_key "${manifest_data}" "${flag_key}" "${dry_run}")"
+  key_source="$(key_source_from_resolution "${resolved}")"
+  print_plan "${manifest_data}" "${key_source}"
+  if [[ "${dry_run}" == "true" ]]; then
+    return 0
+  fi
+  require_cmd opencode
+  api_key="$(api_key_from_resolution "${resolved}")"
+  apply_manifest "${manifest_data}" "${api_key}"
+}
+
+main "$@"

--- a/scripts/aid-byok-apply.test.sh
+++ b/scripts/aid-byok-apply.test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# E2E-style smoke test for BYOK apply/remove scripts.
+# Creates sandboxed opencode/aid homes and stubs the opencode models command.
+# Dependencies: bash, jq, mktemp, mkdir, chmod, grep, stat, ls, wc, rm.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/aid-byok-test.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fail() {
+  echo "test failed: $*" >&2
+  exit 1
+}
+
+file_mode() {
+  local path="$1"
+  if stat -f '%Lp' "${path}" >/dev/null 2>&1; then
+    stat -f '%Lp' "${path}"
+    return 0
+  fi
+  stat -c '%a' "${path}"
+}
+
+write_stub_opencode() {
+  local bin_dir="$1"
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/opencode" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != "models" ]]; then
+  echo "unsupported opencode stub command: ${1:-}" >&2
+  exit 1
+fi
+config="${OPENCODE_CONFIG_DIR}/opencode.json"
+if [[ ! -f "${config}" ]]; then
+  exit 0
+fi
+jq -r '
+  (.provider // {})
+  | to_entries[]
+  | .key as $provider
+  | (.value.models // {})
+  | keys[]
+  | "\($provider)/\(.)"
+' "${config}"
+STUB
+  chmod +x "${bin_dir}/opencode"
+}
+
+write_manifest() {
+  local manifest="$1"
+  cat > "${manifest}" <<'TOML'
+[byok]
+id = "acme"
+display_name = "ACME (token = #abc)"
+protocol = "openai"
+base_url = "https://api.acme.example/v1"
+key_env = "ACME_API_KEY"
+default_model = "acme-pro"
+timeout_ms = 300000
+
+[[byok.model]]
+id = "acme-pro"
+name = "ACME Pro"
+context = 131072
+output = 8192
+tool_call = true
+reasoning = false
+
+[[byok.model]]
+id = "acme-mini"
+context = 32768
+output = 4096
+
+[byok.capabilities]
+research = 5
+simple_edit = 6
+complex_impl = 5
+frontend = 4
+debugging = 5
+testing = 5
+refactoring = 5
+documentation = 5
+TOML
+}
+
+assert_applied() {
+  local config_path="$1"
+  local auth_path="$2"
+  local agent_path="$3"
+  jq -e '.provider.acme.npm == "@ai-sdk/openai-compatible"' "${config_path}" >/dev/null
+  jq -e '.provider.acme.name == "ACME (token = #abc)"' "${config_path}" >/dev/null
+  jq -e '.provider.acme.options.baseURL == "https://api.acme.example/v1"' "${config_path}" >/dev/null
+  jq -e '.provider.acme.models["acme-pro"].limit.context == 131072' "${config_path}" >/dev/null
+  jq -e '.provider.acme.models["acme-pro"].reasoning == false' "${config_path}" >/dev/null
+  jq -e '.provider.acme.models["acme-mini"].tool_call == true' "${config_path}" >/dev/null
+  jq -e '.acme == {"type":"api","key":"test-key"}' "${auth_path}" >/dev/null
+  grep -Fqx '# aid-byok-generated: acme' "${agent_path}"
+  grep -Fq 'opencode run --model acme/acme-pro' "${agent_path}"
+  grep -Fq 'simple_edit = 6' "${agent_path}"
+}
+
+assert_removed() {
+  local config_path="$1"
+  local auth_path="$2"
+  local agent_path="$3"
+  jq -e '(.provider.acme // null) == null' "${config_path}" >/dev/null
+  jq -e '(.acme // null) == null' "${auth_path}" >/dev/null
+  [[ ! -e "${agent_path}" ]] || fail "generated agent still exists"
+}
+
+main() {
+  local bin_dir="${tmp_dir}/bin"
+  local manifest="${tmp_dir}/acme.toml"
+  local config_dir="${tmp_dir}/config"
+  local auth_dir="${tmp_dir}/auth"
+  local aid_home="${tmp_dir}/aid"
+  local config_path="${config_dir}/opencode.json"
+  local auth_path="${auth_dir}/auth.json"
+  local agent_path="${aid_home}/agents/acme.toml"
+  local auth_backup backup_count backup_mode
+
+  write_stub_opencode "${bin_dir}"
+  write_manifest "${manifest}"
+  mkdir -p "${config_dir}" "${auth_dir}"
+  printf '{"provider":{"opencode-go":{"name":"keep-me","models":{}}}}\n' > "${config_path}"
+  printf '{}\n' > "${auth_path}"
+  chmod 644 "${auth_path}"
+
+  export PATH="${bin_dir}:${PATH}"
+  export OPENCODE_CONFIG_DIR="${config_dir}"
+  export OPENCODE_AUTH_DIR="${auth_dir}"
+  export AID_HOME="${aid_home}"
+  export ACME_API_KEY="test-key"
+
+  bash "${repo_root}/scripts/aid-byok-apply.sh" "${manifest}" >/dev/null
+  assert_applied "${config_path}" "${auth_path}" "${agent_path}"
+  jq -e '.provider["opencode-go"].name == "keep-me"' "${config_path}" >/dev/null
+  auth_backup="$(ls "${auth_path}".bak.*)"
+  backup_mode="$(file_mode "${auth_backup}")"
+  [[ "${backup_mode}" == "600" ]] || fail "auth backup mode was ${backup_mode}, expected 600"
+
+  bash "${repo_root}/scripts/aid-byok-apply.sh" "${manifest}" >/dev/null
+  assert_applied "${config_path}" "${auth_path}" "${agent_path}"
+  backup_count="$(ls "${auth_path}".bak.* "${config_path}".bak.* | wc -l | tr -d ' ')"
+  [[ "${backup_count}" == "2" ]] || fail "expected one backup set, found ${backup_count} files"
+
+  bash "${repo_root}/scripts/aid-byok-remove.sh" "${manifest}" >/dev/null
+  assert_removed "${config_path}" "${auth_path}" "${agent_path}"
+  jq -e '.provider["opencode-go"].name == "keep-me"' "${config_path}" >/dev/null
+}
+
+main "$@"

--- a/scripts/aid-byok-lib.sh
+++ b/scripts/aid-byok-lib.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Shared helpers for BYOK provider scripts.
+# Exports manifest parsing, path defaults, JSON builders, and agent TOML generation.
+# Dependencies: bash, python3, jq, date, mkdir, cp, chmod.
+
+fail() {
+  echo "byok failed: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+byok_config_dir() {
+  printf '%s\n' "${OPENCODE_CONFIG_DIR:-${HOME}/.config/opencode}"
+}
+
+byok_auth_dir() {
+  printf '%s\n' "${OPENCODE_AUTH_DIR:-${HOME}/.local/share/opencode}"
+}
+
+byok_aid_home() {
+  printf '%s\n' "${AID_HOME:-${HOME}/.aid}"
+}
+
+toml_quote() {
+  jq -Rn --arg value "$1" '$value'
+}
+
+manifest_json() {
+  local manifest="$1"
+  [[ -f "${manifest}" ]] || fail "manifest not found: ${manifest}"
+  command -v python3 >/dev/null 2>&1 || fail "python3 not found; required for TOML parsing"
+  python3 - "${manifest}" <<'PY'
+import json
+import sys
+import tomllib
+
+path = sys.argv[1]
+try:
+    with open(path, "rb") as manifest_file:
+        data = tomllib.load(manifest_file)
+except tomllib.TOMLDecodeError as exc:
+    print(f"byok failed: invalid manifest TOML: {exc}", file=sys.stderr)
+    sys.exit(1)
+except OSError as exc:
+    print(f"byok failed: could not read manifest: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+byok = data.get("byok", {})
+if not isinstance(byok, dict):
+    byok = {}
+json.dump(byok, sys.stdout, separators=(",", ":"))
+print()
+PY
+}
+
+validate_manifest() {
+  local manifest_data="$1"
+  jq -e '
+    (.id | type == "string" and length > 0) and
+    (.protocol == "openai") and
+    (.base_url | type == "string" and length > 0) and
+    (.default_model | type == "string" and length > 0) and
+    ((.model // []) | length > 0) and
+    all(.model[]; (.id | type == "string" and length > 0)
+      and (.context | type == "number")
+      and (.output | type == "number"))
+  ' <<< "${manifest_data}" >/dev/null \
+    || fail "manifest must define byok id, protocol=openai, base_url, default_model, and model id/context/output"
+
+  local id
+  id="$(jq -r '.id' <<< "${manifest_data}")"
+  [[ "${id}" =~ ^[A-Za-z0-9._-]+$ ]] || fail "provider id contains unsupported characters: ${id}"
+}
+
+resolve_api_key() {
+  local manifest_data="$1"
+  local flag_key="$2"
+  local dry_run="$3"
+  local api_key key_env
+  api_key="$(jq -r '.api_key // ""' <<< "${manifest_data}")"
+  key_env="$(jq -r '.key_env // ""' <<< "${manifest_data}")"
+
+  if [[ -n "${flag_key}" ]]; then
+    printf '%s\n' "flag:${flag_key}"
+    return 0
+  fi
+  if [[ -n "${api_key}" ]]; then
+    printf '%s\n' "manifest:${api_key}"
+    return 0
+  fi
+  if [[ -n "${key_env}" ]]; then
+    if [[ "${dry_run}" == "true" && -z "${!key_env:-}" ]]; then
+      printf '%s\n' "env:${key_env}:"
+      return 0
+    fi
+    [[ -n "${!key_env:-}" ]] || fail "environment variable ${key_env} is not set"
+    printf '%s\n' "env:${key_env}:${!key_env}"
+    return 0
+  fi
+  fail "no API key found; use --key, api_key, or key_env"
+}
+
+api_key_from_resolution() {
+  local resolved="$1"
+  case "${resolved}" in
+    flag:*|manifest:*) printf '%s\n' "${resolved#*:}" ;;
+    env:*:*) printf '%s\n' "${resolved#*:*:}" ;;
+    *) fail "invalid key resolution" ;;
+  esac
+}
+
+key_source_from_resolution() {
+  local resolved="$1"
+  case "${resolved}" in
+    flag:*) printf '%s\n' "--key flag" ;;
+    manifest:*) printf '%s\n' "manifest api_key" ;;
+    env:*:*)
+      local without_prefix="${resolved#env:}"
+      printf '%s\n' "env ${without_prefix%%:*}"
+      ;;
+    *) fail "invalid key resolution" ;;
+  esac
+}
+
+provider_block_json() {
+  local manifest_data="$1"
+  jq '
+    {
+      npm: "@ai-sdk/openai-compatible",
+      name: (.display_name // .id),
+      options: (
+        {baseURL: .base_url}
+        + (if has("timeout_ms") then {timeout: .timeout_ms} else {} end)
+      ),
+      models: (
+        reduce .model[] as $model ({};
+          .[$model.id] = {
+            name: ($model.name // $model.id),
+            tool_call: (if $model.tool_call == null then true else $model.tool_call end),
+            reasoning: (if $model.reasoning == null then false else $model.reasoning end),
+            limit: {context: $model.context, output: $model.output}
+          }
+        )
+      )
+    }
+  ' <<< "${manifest_data}"
+}
+
+ensure_json_file() {
+  local path="$1"
+  mkdir -p "$(dirname "${path}")"
+  if [[ ! -f "${path}" ]]; then
+    printf '{}\n' > "${path}"
+  fi
+  jq -e . "${path}" >/dev/null || fail "invalid JSON file: ${path}"
+}
+
+backup_file() {
+  local path="$1"
+  local ts="$2"
+  local backup="${path}.bak.${ts}"
+  cp "${path}" "${backup}"
+  chmod 600 "${backup}"
+  printf '%s\n' "${backup}"
+}
+
+write_agent_toml() {
+  local manifest_data="$1"
+  local agent_path="$2"
+  local id default_model display_name model_ref wrapper_args
+  id="$(jq -r '.id' <<< "${manifest_data}")"
+  default_model="$(jq -r '.default_model' <<< "${manifest_data}")"
+  display_name="$(jq -r '.display_name // .id' <<< "${manifest_data}")"
+  model_ref="${id}/${default_model}"
+  wrapper_args="$(jq -cn \
+    --arg script "exec opencode run --model ${model_ref} \"\$@\"" \
+    --arg label "aid-byok-${id}" \
+    '["-lc", $script, $label]')"
+
+  {
+    printf '# aid-byok-generated: %s\n' "${id}"
+    printf '# Auto-generated by scripts/aid-byok-apply.sh; remove with scripts/aid-byok-remove.sh.\n'
+    printf '[agent]\n'
+    printf 'id = %s\n' "$(toml_quote "${id}")"
+    printf 'display_name = %s\n' "$(toml_quote "${display_name}")"
+    printf 'command = "bash"\n'
+    printf 'prompt_mode = "arg"\n'
+    printf 'fixed_args = %s\n' "${wrapper_args}"
+    printf 'trust_tier = "api"\n'
+    jq -r '
+      .capabilities // empty
+      | to_entries
+      | if length > 0 then
+          "\n[agent.capabilities]\n" + (map("\(.key) = \(.value)") | join("\n"))
+        else empty end
+    ' <<< "${manifest_data}"
+  } > "${agent_path}"
+}

--- a/scripts/aid-byok-probe.sh
+++ b/scripts/aid-byok-probe.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Probes a BYOK OpenAI-compatible endpoint for tool-call behavior.
+# Sends a chat completion with one dummy tool and reports the provider response shape.
+# Dependencies: bash, jq, curl, mktemp, rm.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/aid-byok-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/aid-byok-probe.sh [--key <api-key>] <manifest.toml>
+
+Exit codes:
+  0  tool_calls present
+  2  no tool_calls present
+EOF
+}
+
+parse_args() {
+  flag_key=""
+  manifest=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --key)
+        [[ $# -ge 2 ]] || fail "--key requires a value"
+        flag_key="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --*)
+        fail "unknown option: $1"
+        ;;
+      *)
+        [[ -z "${manifest}" ]] || fail "only one manifest path is supported"
+        manifest="$1"
+        shift
+        ;;
+    esac
+  done
+  [[ -n "${manifest}" ]] || fail "missing manifest path"
+}
+
+request_json() {
+  local model="$1"
+  local prompt="What's the weather in Tokyo? Use the tool."
+  jq -cn --arg model "${model}" --arg prompt "${prompt}" '{
+    model: $model,
+    messages: [
+      {role: "user", content: $prompt}
+    ],
+    tools: [{
+      type: "function",
+      function: {
+        name: "get_weather",
+        description: "Return current weather for a city.",
+        parameters: {
+          type: "object",
+          properties: {city: {type: "string"}},
+          required: ["city"]
+        }
+      }
+    }],
+    tool_choice: "auto",
+    max_tokens: 128
+  }'
+}
+
+probe_manifest() {
+  local manifest_data="$1"
+  local api_key="$2"
+  local base_url model url body_file status has_tool_calls finish_reason preview
+  base_url="$(jq -r '.base_url' <<< "${manifest_data}")"
+  model="$(jq -r '.default_model' <<< "${manifest_data}")"
+  url="${base_url%/}/chat/completions"
+  body_file="$(mktemp "${TMPDIR:-/tmp}/aid-byok-probe.XXXXXX")"
+
+  status="$(curl -sS -o "${body_file}" -w '%{http_code}' \
+    -H "Authorization: Bearer ${api_key}" \
+    -H "Content-Type: application/json" \
+    -d "$(request_json "${model}")" \
+    "${url}")" || {
+      rm -f "${body_file}"
+      fail "curl request failed"
+    }
+
+  if [[ ! "${status}" =~ ^2 ]]; then
+    printf 'HTTP status: %s\n' "${status}" >&2
+    jq -r '.error.message // .message // .' "${body_file}" >&2 || true
+    rm -f "${body_file}"
+    exit 1
+  fi
+
+  has_tool_calls="$(jq -r '((.choices[0].message.tool_calls // []) | length) > 0' "${body_file}")"
+  finish_reason="$(jq -r '.choices[0].finish_reason // "unknown"' "${body_file}")"
+  preview="$(jq -r '.choices[0].message.content // ""' "${body_file}")"
+  preview="${preview//$'\n'/ }"
+  preview="${preview:0:120}"
+  rm -f "${body_file}"
+
+  if [[ "${has_tool_calls}" == "true" ]]; then
+    printf 'tool_calls: yes\n'
+    printf 'finish_reason: %s\n' "${finish_reason}"
+    printf 'content: %s\n' "${preview}"
+    return 0
+  fi
+  printf 'tool_calls: no\n'
+  printf 'finish_reason: %s\n' "${finish_reason}"
+  printf 'content: %s\n' "${preview}"
+  return 2
+}
+
+main() {
+  require_cmd jq
+  require_cmd curl
+  parse_args "$@"
+  local manifest_data resolved api_key
+  manifest_data="$(manifest_json "${manifest}")"
+  validate_manifest "${manifest_data}"
+  resolved="$(resolve_api_key "${manifest_data}" "${flag_key}" "false")"
+  api_key="$(api_key_from_resolution "${resolved}")"
+  probe_manifest "${manifest_data}" "${api_key}"
+}
+
+main "$@"

--- a/scripts/aid-byok-remove.sh
+++ b/scripts/aid-byok-remove.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Removes a BYOK provider from opencode config and auth state.
+# Deletes the matching aid agent only when it has the BYOK generated marker.
+# Dependencies: bash, jq, opencode, grep, date, mktemp, mkdir, cp, mv, chmod, rm.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/aid-byok-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/aid-byok-remove.sh <manifest.toml|provider-id>
+
+Environment overrides:
+  OPENCODE_CONFIG_DIR  Defaults to ~/.config/opencode
+  OPENCODE_AUTH_DIR    Defaults to ~/.local/share/opencode
+  AID_HOME             Defaults to ~/.aid
+EOF
+}
+
+provider_id_from_arg() {
+  local input="$1"
+  local manifest_data id
+  if [[ -f "${input}" ]]; then
+    manifest_data="$(manifest_json "${input}")"
+    id="$(jq -r '.id // ""' <<< "${manifest_data}")"
+  else
+    id="${input}"
+  fi
+  [[ "${id}" =~ ^[A-Za-z0-9._-]+$ ]] || fail "invalid provider id: ${id}"
+  printf '%s\n' "${id}"
+}
+
+remove_generated_agent() {
+  local id="$1"
+  local agent_path
+  agent_path="$(byok_aid_home)/agents/${id}.toml"
+  [[ -f "${agent_path}" ]] || return 0
+  if grep -Fqx "# aid-byok-generated: ${id}" "${agent_path}"; then
+    rm -f "${agent_path}"
+    return 0
+  fi
+  printf 'Skipping non-generated aid agent: %s\n' "${agent_path}" >&2
+}
+
+remove_provider() {
+  local id="$1"
+  local config_path auth_path agent_path ts config_backup auth_backup agent_backup tmp pattern
+  config_path="$(byok_config_dir)/opencode.json"
+  auth_path="$(byok_auth_dir)/auth.json"
+  agent_path="$(byok_aid_home)/agents/${id}.toml"
+  ts="$(date +%s)"
+
+  ensure_json_file "${config_path}"
+  ensure_json_file "${auth_path}"
+  config_backup="$(backup_file "${config_path}" "${ts}")"
+  auth_backup="$(backup_file "${auth_path}" "${ts}")"
+  agent_backup=""
+  if [[ -f "${agent_path}" ]]; then
+    agent_backup="$(backup_file "${agent_path}" "${ts}")"
+  fi
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/aid-byok-config.XXXXXX")"
+  jq --arg id "${id}" 'if .provider then del(.provider[$id]) else . end' \
+    "${config_path}" > "${tmp}"
+  mv "${tmp}" "${config_path}"
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/aid-byok-auth.XXXXXX")"
+  jq --arg id "${id}" 'del(.[$id])' "${auth_path}" > "${tmp}"
+  mv "${tmp}" "${auth_path}"
+  chmod 600 "${auth_path}"
+  remove_generated_agent "${id}"
+
+  pattern="^${id//./\\.}/"
+  if opencode models | grep -E "${pattern}" >/dev/null; then
+    cp "${config_backup}" "${config_path}"
+    cp "${auth_backup}" "${auth_path}"
+    chmod 600 "${auth_path}"
+    if [[ -n "${agent_backup}" && -f "${agent_backup}" ]]; then
+      cp "${agent_backup}" "${agent_path}"
+    fi
+    fail "opencode still lists provider ${id}; restored config, auth, and agent backups"
+  fi
+
+  printf 'BYOK provider removed: %s\n' "${id}"
+}
+
+main() {
+  require_cmd jq
+  require_cmd opencode
+  if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    [[ $# -eq 1 ]] && exit 0
+    exit 1
+  fi
+  local id
+  id="$(provider_id_from_arg "$1")"
+  remove_provider "${id}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds a reusable BYOK pattern so any third-party OpenAI-compatible LLM provider can be wired into aid via opencode's custom-provider config — without disturbing opencode-go or other existing providers
- Delivered as bash + jq + python3 scripts (no Rust changes); promotion to a Rust `aid byok` subcommand is a future iteration
- MiMo (Xiaomi official, `https://token-plan-sgp.xiaomimimo.com/v1`) is the canonical example; live wiring already in place in user config

## Files

| File | Purpose |
|---|---|
| `docs/byok-pattern.md` | Manifest schema, walkthrough, remove flow |
| `scripts/aid-byok-apply.sh` | Patch opencode.json + auth.json + generate aid agent. Idempotent, `--dry-run`, backup-first, restore on verify-fail |
| `scripts/aid-byok-probe.sh` | Verify endpoint actually emits OpenAI `tool_calls` |
| `scripts/aid-byok-remove.sh` | Clean teardown with marker-aware agent protection |
| `scripts/aid-byok-lib.sh` | Shared helpers; manifest parsed via `python3 -m tomllib` |
| `scripts/aid-byok-apply.test.sh` | Sandboxed apply/remove/idempotency/perm tests |
| `examples/byok/mimo.toml` | Canonical MiMo example, uses `key_env` over literal `api_key` |

## Safety properties

- `apply` uses `jq '.provider[$id] = $block'` (keyed assignment), never wholesale `.provider = {}` — sibling providers (opencode-go, etc.) untouched
- Hand-written aid agent TOMLs lacking `# aid-byok-generated: <id>` marker are refused (apply errors out, remove leaves them in place)
- Auth backups `chmod 600` immediately after copy (prevents inheriting 644 mode and leaking plaintext keys)
- `--dry-run` writes nothing, including no backups
- Verify step uses anchored `grep -E "^${id}/"` so `mimo-test` doesn't false-match `mimo`
- All paths overridable via `OPENCODE_CONFIG_DIR` / `OPENCODE_AUTH_DIR` / `AID_HOME` for sandboxed tests

## Cross-audit (`t-9a2a`)

19 PASS / 4 FAIL initially. All four FAILs addressed in this same commit:

| # | Issue | Fix |
|---|---|---|
| 1 | Auth backups inherited 644 perms | `chmod 600` on every backup in `backup_file` |
| 2 | Awk-based TOML parser failed on edge cases | Replaced with `python3 -m tomllib` (stdlib in 3.11+) |
| 3 | `manifest_json` was 86 lines (>50 line rule) | Now 27 lines after parser swap |
| 4 | Re-apply created redundant backups | `cmp -s` skip when target content unchanged |

Audit report at `result-t-9a2a.md` (untracked, in worktree only).

## Test plan

- [x] `bash scripts/aid-byok-apply.test.sh` exits 0 (sandboxed apply + remove + sibling-preservation + idempotency + auth-backup-perms)
- [x] `bash scripts/aid-byok-apply.sh --dry-run examples/byok/mimo.toml` prints sensible plan, writes nothing
- [x] `bash scripts/aid-byok-probe.sh --key <live-mimo-key> examples/byok/mimo.toml` reports `tool_calls: yes`
- [x] `cargo check` passes (no Rust changes)
- [x] All scripts ≤ 300 lines; all functions ≤ 50 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)