### PR TITLE
fix(dispatch): update log_path when task ID is auto-suffixed

### DIFF
--- a/src/cmd/run_dispatch_prepare.rs
+++ b/src/cmd/run_dispatch_prepare.rs
@@ -236,14 +236,7 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
         store.insert_task(&task)?;
     }
     if emit_gitbutler_setup_hint {
-        let _ = store.insert_event(&TaskEvent {
-            task_id: task_id.clone(),
-            timestamp: Local::now(),
-            event_kind: EventKind::Milestone,
-            detail: "Hint: run `but setup` from the main repo to enable GitButler integration for future tasks."
-                .to_string(),
-            metadata: None,
-        });
+        super::run_dispatch_resolve::insert_gitbutler_setup_hint(store, &task_id);
     }
     if !args.dry_run
         && let (Some(wt), Some(repo)) = (wt_path.as_deref(), repo_path.as_deref())

--- a/src/cmd/run_dispatch_prepare.rs
+++ b/src/cmd/run_dispatch_prepare.rs
@@ -5,10 +5,8 @@ use anyhow::Result;
 use chrono::Local;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use crate::{agent, paths, session};
-use crate::project::{self, ProjectConfig};
-use crate::store::{Store, TaskCompletionUpdate};
-use crate::types::*;
+use crate::{agent, paths, project::{self, ProjectConfig}, session};
+use crate::{store::{Store, TaskCompletionUpdate}, types::*};
 use super::run_dispatch_resolve::{apply_project_defaults, resolve_agent_setup};
 use super::run_validate::{IdConflict, resolve_id_conflict, validate_dispatch};
 use super::{RunArgs, context_file_from_spec, resolve_max_duration_mins, resolve_prompt_input, run_prompt};
@@ -47,7 +45,7 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
         }
         None => TaskId::generate(),
     };
-    let log_path = paths::log_path(task_id.as_str());
+    let mut log_path = paths::log_path(task_id.as_str());
     let workgroup = run_prompt::load_workgroup(store, args.group.as_deref())?;
     let explicit_repo_path = crate::repo_root::resolve_explicit_repo_path(args.repo_root.as_deref(), args.repo.as_deref())?;
     let caller = session::current_caller();
@@ -222,8 +220,10 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
             }
             IdConflict::AutoSuffix(new_id) => {
                 aid_info!("[aid] ID '{}' already exists, using '{}'", task_id, new_id);
-                task.id = TaskId(new_id.clone());
                 task_id = TaskId(new_id);
+                log_path = paths::log_path(task_id.as_str());
+                task.id = task_id.clone();
+                task.log_path = Some(log_path.to_string_lossy().to_string());
                 store.insert_task(&task)?;
             }
         }

--- a/src/cmd/run_dispatch_prepare.rs
+++ b/src/cmd/run_dispatch_prepare.rs
@@ -224,6 +224,11 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
                 log_path = paths::log_path(task_id.as_str());
                 task.id = task_id.clone();
                 task.log_path = Some(log_path.to_string_lossy().to_string());
+                // Re-key the worktree lock: it was acquired with the pre-suffix ID
+                // before conflict resolution, so its owner field is now stale.
+                if let Some(ref wt) = wt_path {
+                    crate::worktree::write_worktree_lock(Path::new(wt), task_id.as_str());
+                }
                 store.insert_task(&task)?;
             }
         }

--- a/src/cmd/run_dispatch_prepare_tests.rs
+++ b/src/cmd/run_dispatch_prepare_tests.rs
@@ -32,6 +32,34 @@ fn report_mode_dirty_skip_uses_narrow_predicate() {
 }
 
 #[test]
+fn prepare_dispatch_updates_log_path_when_id_is_auto_suffixed() {
+    let temp = tempfile::tempdir().unwrap();
+    let _guard = crate::paths::AidHomeGuard::set(temp.path());
+    let store = Arc::new(Store::open_memory().unwrap());
+    let mut first = RunArgs {
+        agent_name: "codex".to_string(),
+        existing_task_id: Some(TaskId("t-ebcf".to_string())),
+        prompt: "Investigate a concrete task routing bug.".to_string(),
+        ..Default::default()
+    };
+    prepare_dispatch(&store, &mut first).unwrap();
+
+    let mut second = RunArgs {
+        agent_name: "codex".to_string(),
+        existing_task_id: Some(TaskId("t-ebcf".to_string())),
+        prompt: "Investigate a concrete task routing bug again.".to_string(),
+        ..Default::default()
+    };
+    let prepared = prepare_dispatch(&store, &mut second).unwrap();
+
+    let expected = crate::paths::log_path("t-ebcf-2");
+    let saved = store.get_task("t-ebcf-2").unwrap().unwrap();
+    assert_eq!(prepared.task_id.as_str(), "t-ebcf-2");
+    assert_eq!(prepared.log_path, expected);
+    assert_eq!(saved.log_path.as_deref(), Some(expected.to_str().unwrap()));
+}
+
+#[test]
 fn prepare_dispatch_uses_task_specific_audit_result_file() {
     let store = Arc::new(Store::open_memory().unwrap());
     let mut args = RunArgs {

--- a/src/cmd/run_dispatch_resolve.rs
+++ b/src/cmd/run_dispatch_resolve.rs
@@ -15,6 +15,18 @@ use crate::usage;
 use super::run_prompt;
 use super::RunArgs;
 
+/// Emit the one-time GitButler setup hint as a task milestone event.
+pub(super) fn insert_gitbutler_setup_hint(store: &Store, task_id: &crate::types::TaskId) {
+    let _ = store.insert_event(&crate::types::TaskEvent {
+        task_id: task_id.clone(),
+        timestamp: chrono::Local::now(),
+        event_kind: crate::types::EventKind::Milestone,
+        detail: "Hint: run `but setup` from the main repo to enable GitButler integration for future tasks."
+            .to_string(),
+        metadata: None,
+    });
+}
+
 pub(super) struct AgentSetup {
     pub agent_kind: AgentKind,
     pub custom_agent_name: Option<String>,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -27,10 +27,10 @@ pub(crate) use baseline::{baseline_contains, extract_baseline_path, extract_base
 pub use path::{aid_worktree_path, aid_worktree_root, is_aid_managed_worktree_path};
 pub use state::{
     branch_has_commits_ahead_of_main, clear_worktree_lock, process_alive_check,
-    try_acquire_worktree_lock, worktree_changed_files,
+    try_acquire_worktree_lock, worktree_changed_files, write_worktree_lock,
 };
 #[cfg(test)]
-pub use state::{check_worktree_lock, write_worktree_lock};
+pub use state::check_worktree_lock;
 pub(crate) use completion::cleanup_completed_worktree;
 use state::{existing_worktree_path, local_branch_exists, prune_worktrees, sync_cargo_lock};
 use validation::{canonical_worktree_path, is_valid_git_worktree};

--- a/src/worktree/lock_tests.rs
+++ b/src/worktree/lock_tests.rs
@@ -3,7 +3,7 @@
 // Deps: super worktree helpers, tempfile, std threading primitives.
 
 use super::{
-    clear_worktree_lock, create_worktree, try_acquire_worktree_lock,
+    check_worktree_lock, clear_worktree_lock, create_worktree, try_acquire_worktree_lock,
 };
 use super::path::WorktreeHomeGuard;
 use super::state::write_worktree_lock;
@@ -46,6 +46,19 @@ fn try_acquire_worktree_lock_rejects_existing_and_recovers_stale_lock() {
         .expect("stale lock should write");
 
     assert!(try_acquire_worktree_lock(dir.path(), "t-after-stale").is_ok());
+}
+
+#[test]
+fn write_worktree_lock_rekeys_owner_to_new_task_id() {
+    // Mirrors the AutoSuffix path: the lock is acquired with the pre-suffix ID,
+    // then re-keyed to the suffixed ID after conflict resolution.
+    let dir = TempDir::new().expect("tempdir should be created");
+
+    try_acquire_worktree_lock(dir.path(), "t-ebcf").expect("lock should be acquired");
+    assert_eq!(check_worktree_lock(dir.path()).as_deref(), Some("t-ebcf"));
+
+    write_worktree_lock(dir.path(), "t-ebcf-2");
+    assert_eq!(check_worktree_lock(dir.path()).as_deref(), Some("t-ebcf-2"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

When an explicit task ID collides with an existing one, aid auto-suffixes it (`t-ebcf` → `t-ebcf-2`). The task record's `log_path` was still computed from the **original** ID, so the background worker wrote events to the wrong log file — `aid show`/`watch` then showed no events for the actual task.

## Fix

In `prepare_dispatch`, on the `IdConflict::AutoSuffix` branch, recompute `log_path` from the new ID and persist it on the task (`task.log_path`) before insert.

## Test

`prepare_dispatch_updates_log_path_when_id_is_auto_suffixed` — dispatches two tasks with the same explicit ID and asserts the second gets `t-ebcf-2` with a matching, persisted `log_path`.

`cargo check` clean.

> Carried over from a prior session's uncommitted work; rebased onto current main (after #128) and conflict-resolved (both new tests in `run_dispatch_prepare_tests.rs` retained).
