### PR TITLE
fix(routing): guard audit/review/verify prompts from cheap-model downgrade

### DIFF
--- a/src/agent/classifier.rs
+++ b/src/agent/classifier.rs
@@ -206,7 +206,7 @@ pub fn is_simple_for_routing(prompt: &str) -> bool {
         && !prompt.contains("```")
         && !prompt.contains("http://")
         && !prompt.contains("https://")
-        && !contains_any(&lower, &["implement", "create module", "design", "architect", "refactor across", "migrate", "security audit", "debug", "investigate", "root cause"])
+        && !contains_any(&lower, &["implement", "create module", "design", "architect", "refactor across", "migrate", "audit", "review", "verify", "debug", "investigate", "root cause"])
 }
 
 /// Word-boundary aware match: "ui" matches " ui " but not "suite".
@@ -267,6 +267,9 @@ mod tests {
     #[test]
     fn simple_prompt_is_routable() {
         assert!(is_simple_for_routing("rename a field"));
+        assert!(!is_simple_for_routing("Cross-audit the parser.rs change"));
+        assert!(!is_simple_for_routing("review this diff"));
+        assert!(!is_simple_for_routing("verify the fix works"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`is_simple_for_routing()` gates whether a short prompt is silently downgraded to the cheapest model by `smart_routing`. Its keyword denylist contained `"security audit"` but not plain `audit`/`cross-audit`/`review`/`verify`. A short prompt like `Cross-audit the parser change` slipped through as "simple" and was routed to the cheapest (nano) model — exactly the wrong model for correctness-critical audit/review work.

## Fix

In the `is_simple_for_routing` denylist only:
- Replace `"security audit"` with `"audit"` — `contains_any` is a substring match, so `"audit"` already covers `cross-audit`, `security audit`, `auditor` (no redundancy).
- Add `"review"` and `"verify"`.

Now audit/review/verify prompts return `false` (not cheap-routable) → `effective_model = None` → no `-m` flag → codex defers to its own configured model (e.g. gpt-5.5). No version is pinned anywhere.

## Tests

Added 3 negative assertions (`Cross-audit ...`, `review this diff`, `verify the fix works` → not routable) and kept the positive case (`rename a field` → routable). All routing tests pass; `cargo check` clean.

## Cross-audit

Independently cross-audited (codex, adversarial checklist) → **SHIP**. Substring false-positives (e.g. `preview` contains `review`) were confirmed to fail in the SAFE direction (over-block → stronger model, never under-block critical work onto a weak model). Word-boundary matching was considered and rejected: it would introduce DANGEROUS under-blocks (`redesign`/`reimplement` would route to cheap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)