### PR TITLE
fix(dispatch): hollow-output guard counts characters, not bytes

### DIFF
--- a/src/cmd/run_lifecycle.rs
+++ b/src/cmd/run_lifecycle.rs
@@ -533,12 +533,12 @@ pub(crate) fn maybe_flag_hollow_output(store: &Store, task_id: &TaskId, task: &T
         metadata: None,
     });
 }
-fn output_content_length(task: &Task) -> usize {
+pub(super) fn output_content_length(task: &Task) -> usize {
     if let Some(ref path) = task.output_path {
         if let Ok(content) = std::fs::read_to_string(path) {
-            return content.trim().len();
+            return content.trim().chars().count();
         }
     }
     let auto_path = crate::paths::task_dir(task.id.as_str()).join("output.md");
-    std::fs::read_to_string(auto_path).map(|content| content.trim().len()).unwrap_or(0)
+    std::fs::read_to_string(auto_path).map(|content| content.trim().chars().count()).unwrap_or(0)
 }

--- a/src/cmd/run_lifecycle_tests.rs
+++ b/src/cmd/run_lifecycle_tests.rs
@@ -5,6 +5,7 @@
 use super::{
     final_dirty_assertion,
     run_dirty::{post_agent_dirty_worktree_cleanup, DirtyWorktreeAction},
+    run_lifecycle::output_content_length,
     RunArgs,
 };
 use crate::{store::Store, test_subprocess, types::*};
@@ -66,6 +67,31 @@ fn task(id: &str, status: TaskStatus) -> Task {
         audit_report_path: None,
         delivery_assessment: None,
     }
+}
+
+#[test]
+fn output_content_length_counts_multibyte_output_as_characters() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("output.md");
+    let content = format!("{}{}", "a".repeat(196), "\u{2019}".repeat(2));
+    assert!(content.len() >= 200);
+    assert!(content.chars().count() < 200);
+    std::fs::write(&output_path, content).unwrap();
+    let mut task = task("t-short-multibyte", TaskStatus::Done);
+    task.output_path = Some(output_path.to_string_lossy().to_string());
+
+    assert!(output_content_length(&task) < 200);
+}
+
+#[test]
+fn output_content_length_keeps_long_ascii_output_at_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("output.md");
+    std::fs::write(&output_path, "a".repeat(200)).unwrap();
+    let mut task = task("t-long-ascii", TaskStatus::Done);
+    task.output_path = Some(output_path.to_string_lossy().to_string());
+
+    assert!(output_content_length(&task) >= 200);
 }
 
 #[test]


### PR DESCRIPTION
## Problem
`maybe_flag_hollow_output` skips flagging when `output_content_length(task) >= 200`, but the helper measured **byte** length (`content.trim().len()`). A real 199-character agent preamble was 205 bytes (two UTF-8 U+2019 curly apostrophes, 3 bytes each), slipping past the 200 threshold — a zero-delivery $5 audit task was silently marked Done with no `HollowOutput` flag.

## Fix
Count **characters** (`content.trim().chars().count()`) in both branches of `output_content_length`. The 200 threshold is a character floor for substantive output; unchanged otherwise.

## Tests
- `output_content_length_counts_multibyte_output_as_characters`: 196×'a' + 2×U+2019 = 202 bytes / 198 chars → returns <200 (would flag hollow). Old byte logic returned 202 (wrongly skipped).
- `output_content_length_keeps_long_ascii_output_at_threshold`: 200 ASCII → ≥200.

## Cross-audit
Adversarially audited (gemini, read-only): char-count correct, both branches updated, threshold untouched, no unwraps/churn. Inverse multibyte risk (short CJK output) assessed low — guard only warns, never fails the task.

Found while diagnosing task t-50e5 (codex audit that delivered only a 199-char preamble yet was marked Done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)