### PR TITLE
test(gemini): serialize env-mutating trust-workspace tests to fix release.sh flake

### DIFF
--- a/src/agent/gemini_v036_tests.rs
+++ b/src/agent/gemini_v036_tests.rs
@@ -4,7 +4,13 @@
 use super::*;
 use crate::agent::{Agent, RunOpts};
 use crate::paths::AidHomeGuard;
+use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 #[test]
 fn build_command_includes_external_context_directories() {
@@ -44,6 +50,7 @@ fn build_command_includes_external_context_directories() {
 
 #[test]
 fn build_command_sets_trust_workspace_env_by_default() {
+    let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let opts = RunOpts {
         dir: None,
         output: None,
@@ -97,6 +104,7 @@ fn build_command_sets_trust_workspace_env_by_default() {
 
 #[test]
 fn build_command_respects_pre_existing_trust_workspace_override() {
+    let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let opts = RunOpts {
         dir: None,
         output: None,


### PR DESCRIPTION
## Problem
`scripts/release.sh`'s parallel `cargo test` intermittently failed `build_command_respects_pre_existing_trust_workspace_override` (`assert!(explicit.is_none())`). `gemini.rs:36` branches on the process-global `GEMINI_CLI_TRUST_WORKSPACE`; two tests in `gemini_v036_tests.rs` mutate that same global var (one removes it expecting the default 'true' branch, one sets it 'false' expecting no override). Run in parallel they race and flake — blocking releases.

## Fix
Serialize the two env-mutating tests with a shared process-wide mutex, matching the existing codebase pattern (`sandbox.rs:167`, `state_tests.rs:38`):
```rust
fn env_lock() -> &'static Mutex<()> {
    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
    LOCK.get_or_init(|| Mutex::new(()))
}
```
Each test acquires `env_lock().lock().unwrap_or_else(|e| e.into_inner())` (poison-tolerant) before touching the env. Test-only; no production change, no new dependency.

## Verification
`cargo check` clean; v036 tests pass 7/7 across 5 consecutive parallel runs (was flaky before). Only `gemini.rs` + these two tests reference the var, so the lock fully covers the contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)