### PR TITLE
fix(dispatch): task ID collisions — widen ID space, retry-on-conflict, insert-before-branch-mutation (#134)

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -75,14 +75,14 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
     // Header
     if show_repo {
         out.push_str(&format!(
-            "{:<10} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<10} {:<20} {:<16} {}\n",
+            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<20} {:<16} {}\n",
             "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Repo", "Caller", "Model"
         ));
         out.push_str(&"-".repeat(165));
         out.push('\n');
     } else {
         out.push_str(&format!(
-            "{:<10} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<10} {:<16} {}\n",
+            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<16} {}\n",
             "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Caller", "Model"
         ));
         out.push_str(&"-".repeat(144));
@@ -134,7 +134,7 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
 
         if show_repo {
             out.push_str(&format!(
-                "{:<10} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<10} {:<20} {:<16} {}\n",
+                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<20} {:<16} {}\n",
                 task.id.as_str(),
                 task.agent_display_name(),
                 status,
@@ -149,7 +149,7 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
             ));
         } else {
             out.push_str(&format!(
-                "{:<10} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<10} {:<16} {}\n",
+                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<16} {}\n",
                 task.id.as_str(),
                 task.agent_display_name(),
                 status,

--- a/src/board.rs
+++ b/src/board.rs
@@ -75,14 +75,14 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
     // Header
     if show_repo {
         out.push_str(&format!(
-            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<20} {:<16} {}\n",
+            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
             "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Repo", "Caller", "Model"
         ));
         out.push_str(&"-".repeat(165));
         out.push('\n');
     } else {
         out.push_str(&format!(
-            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<16} {}\n",
+            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
             "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Caller", "Model"
         ));
         out.push_str(&"-".repeat(144));
@@ -134,7 +134,7 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
 
         if show_repo {
             out.push_str(&format!(
-                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<20} {:<16} {}\n",
+                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
                 task.id.as_str(),
                 task.agent_display_name(),
                 status,
@@ -149,7 +149,7 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
             ));
         } else {
             out.push_str(&format!(
-                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<10} {:<12} {:<16} {}\n",
+                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
                 task.id.as_str(),
                 task.agent_display_name(),
                 status,

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -31,6 +31,8 @@ mod run_post;
 mod run_gc;
 #[path = "run_dispatch_resolve.rs"]
 mod run_dispatch_resolve;
+#[path = "run_dispatch_claim.rs"]
+mod run_dispatch_claim;
 #[path = "run_dispatch_prepare.rs"]
 mod run_dispatch_prepare;
 #[path = "run_dispatch_execute.rs"]

--- a/src/cmd/run_dispatch_claim.rs
+++ b/src/cmd/run_dispatch_claim.rs
@@ -1,0 +1,85 @@
+// Task ID claiming for dispatch preparation.
+// Exports bounded insert helpers for generated and explicit task IDs.
+// Deps: paths, Store, Task/TaskId, run ID-conflict validation.
+use anyhow::{Result, anyhow};
+use std::path::PathBuf;
+
+use crate::{paths, store::Store, types::{Task, TaskId}};
+
+use super::run_validate::{IdConflict, resolve_id_conflict};
+
+const MAX_GENERATED_ID_INSERT_ATTEMPTS: usize = 8;
+const SQLITE_CONSTRAINT_PRIMARYKEY: i32 = 1555;
+
+pub(super) fn insert_task_claiming_id(
+    store: &Store,
+    task: &mut Task,
+    task_id: &mut TaskId,
+    log_path: &mut PathBuf,
+    explicit_id: bool,
+) -> Result<()> {
+    if explicit_id {
+        return insert_explicit_task_id(store, task, task_id, log_path);
+    }
+    insert_generated_task_id(store, task, task_id, log_path)
+}
+
+fn insert_explicit_task_id(
+    store: &Store,
+    task: &mut Task,
+    task_id: &mut TaskId,
+    log_path: &mut PathBuf,
+) -> Result<()> {
+    match resolve_id_conflict(store, task_id.as_str())? {
+        IdConflict::None => store.insert_task(task),
+        IdConflict::ReplaceWaiting => store.replace_waiting_task(task),
+        IdConflict::Running => {
+            anyhow::bail!(
+                "Task '{}' is still running. Stop it first: aid stop {}",
+                task_id, task_id
+            );
+        }
+        IdConflict::AutoSuffix(new_id) => {
+            aid_info!("[aid] ID '{}' already exists, using '{}'", task_id, new_id);
+            *task_id = TaskId(new_id);
+            *log_path = paths::log_path(task_id.as_str());
+            task.id = task_id.clone();
+            task.log_path = Some(log_path.to_string_lossy().to_string());
+            store.insert_task(task)
+        }
+    }
+}
+
+fn insert_generated_task_id(
+    store: &Store,
+    task: &mut Task,
+    task_id: &mut TaskId,
+    log_path: &mut PathBuf,
+) -> Result<()> {
+    for attempt in 1..=MAX_GENERATED_ID_INSERT_ATTEMPTS {
+        task.id = task_id.clone();
+        task.log_path = Some(log_path.to_string_lossy().to_string());
+        match store.insert_task(task) {
+            Ok(()) => return Ok(()),
+            Err(err) if is_primary_key_conflict(&err) && attempt < MAX_GENERATED_ID_INSERT_ATTEMPTS => {
+                *task_id = TaskId::generate();
+                *log_path = paths::log_path(task_id.as_str());
+            }
+            Err(err) if is_primary_key_conflict(&err) => {
+                return Err(anyhow!(
+                    "failed to allocate unique task ID after {MAX_GENERATED_ID_INSERT_ATTEMPTS} attempts"
+                ));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(anyhow!("failed to allocate unique task ID"))
+}
+
+fn is_primary_key_conflict(err: &anyhow::Error) -> bool {
+    let Some(rusqlite::Error::SqliteFailure(sqlite_err, _)) =
+        err.downcast_ref::<rusqlite::Error>() else {
+            return false;
+        };
+    sqlite_err.extended_code == SQLITE_CONSTRAINT_PRIMARYKEY
+}

--- a/src/cmd/run_dispatch_prepare.rs
+++ b/src/cmd/run_dispatch_prepare.rs
@@ -3,13 +3,14 @@
 // Deps: run args/validation helpers, agent registry, project defaults, store.
 use anyhow::Result;
 use chrono::Local;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{path::{Path, PathBuf}, sync::Arc};
 use crate::{agent, paths, project::{self, ProjectConfig}, session};
 use crate::{store::{Store, TaskCompletionUpdate}, types::*};
-use super::run_dispatch_resolve::{apply_project_defaults, resolve_agent_setup};
-use super::run_validate::{IdConflict, resolve_id_conflict, validate_dispatch};
+use super::run_dispatch_claim::insert_task_claiming_id;
+use super::run_dispatch_resolve::{AgentSetup, apply_project_defaults, resolve_agent_setup};
+use super::run_validate::validate_dispatch;
 use super::{RunArgs, context_file_from_spec, resolve_max_duration_mins, resolve_prompt_input, run_prompt};
+
 pub(super) struct PreparedDispatch {
     pub detected_project: Option<ProjectConfig>,
     pub agent_kind: AgentKind,
@@ -26,10 +27,33 @@ pub(super) struct PreparedDispatch {
     pub wt_path: Option<String>,
     pub effective_dir: Option<String>,
 }
+
+struct WorktreeSetup {
+    wt_path: Option<String>, wt_branch: Option<String>, effective_dir: Option<String>,
+    repo_path: Option<String>, fresh_worktree: bool, emit_gitbutler_setup_hint: bool,
+}
+
+struct WorktreeLockGuard { path: Option<String> }
+
+impl WorktreeLockGuard {
+    fn new() -> Self { Self { path: None } }
+    fn hold(&mut self, path: &str) { self.path = Some(path.to_string()); }
+    fn disarm(&mut self) { self.path = None; }
+}
+
+impl Drop for WorktreeLockGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take() {
+            crate::worktree::clear_worktree_lock(Path::new(&path));
+        }
+    }
+}
+
 fn stale_worktree_dir_error(dir: &str, branch: Option<&str>) -> String {
     branch.map(|branch| format!("batch file / task dir missing in worktree: {dir} - workgroup state is stale, run aid worktree remove {branch} and retry"))
         .unwrap_or_else(|| format!("working directory does not exist: {dir}"))
 }
+
 pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result<PreparedDispatch> {
     args.prompt = resolve_prompt_input(&args.prompt, args.prompt_file.as_deref())?;
     args.prompt_file = None;
@@ -38,160 +62,77 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
     let detected_project = project::detect_project();
     apply_project_defaults(args, detected_project.as_ref());
     let agent_setup = resolve_agent_setup(store, args)?;
-    let mut task_id = match args.existing_task_id.clone() {
-        Some(id) => {
-            crate::sanitize::validate_task_id(id.as_str())?;
-            id
-        }
-        None => TaskId::generate(),
-    };
+    let explicit_id = args.existing_task_id.is_some();
+    let mut task_id = initial_task_id(args)?;
     let mut log_path = paths::log_path(task_id.as_str());
     let workgroup = run_prompt::load_workgroup(store, args.group.as_deref())?;
     let explicit_repo_path = crate::repo_root::resolve_explicit_repo_path(args.repo_root.as_deref(), args.repo.as_deref())?;
     let caller = session::current_caller();
-    let worktree_setup = (|| -> Result<_> {
-        let (wt_path, wt_branch, effective_dir, resolved_repo, fresh_worktree) =
-            run_prompt::resolve_worktree_paths(args, explicit_repo_path.as_deref())?;
-        let repo_path = resolved_repo.clone().or(explicit_repo_path.clone());
-        let mut emit_gitbutler_setup_hint = false;
-        if let Some(ref wt) = wt_path {
-            if let Err(holder) = crate::worktree::try_acquire_worktree_lock(Path::new(wt), task_id.as_str()) {
-                anyhow::bail!("Worktree {wt} is locked by task {holder} — concurrent access prevented. Use separate worktree names for parallel tasks.");
-            }
-        }
-        if let Some(ref wt) = wt_path
-            && std::env::var("AID_GITBUTLER").map(|value| value != "0").unwrap_or(true)
-            && let Some(ref project) = detected_project
-            && let Some(repo) = repo_path.as_deref()
-        {
-            let worktree = Path::new(wt);
-            let plan = crate::gitbutler::task_worktree_integration_plan(
-                Path::new(repo),
-                worktree,
-                project.gitbutler_mode(),
-                agent_setup.agent_kind.as_str(),
-            );
-            emit_gitbutler_setup_hint = plan.emit_setup_hint;
-            if plan.install_claude_hooks {
-                if let Err(err) = crate::gitbutler::install_claude_hooks(worktree) {
-                    aid_warn!("[aid] gitbutler: failed to install claude hooks: {err}");
-                }
-            } else if let Some(command) = plan.on_done_command {
-                args.on_done = Some(match args.on_done.take() {
-                    Some(existing) if !existing.trim().is_empty() => format!("{existing} && {command}"),
-                    _ => command,
-                });
-            }
-        }
-        if let (Some(wt), Some(repo)) = (wt_path.as_deref(), repo_path.as_deref()) {
-            let context_files: Vec<String> = args.context.iter().map(|spec| context_file_from_spec(spec)).collect();
-            let synced = crate::worktree::sync_context_files_into_worktree(
-                Path::new(repo),
-                Path::new(wt),
-                &context_files,
-            );
-            if !synced.is_empty() {
-                aid_info!(
-                    "[aid] Synced {} context file(s) into worktree: {}",
-                    synced.len(),
-                    synced.join(", ")
-                );
-            }
-        }
-        if let (Some(_), Some(dir)) = (wt_path.as_deref(), effective_dir.as_deref()) && !Path::new(dir).is_dir() {
-            anyhow::bail!(
-                "{}",
-                stale_worktree_dir_error(dir, wt_branch.as_deref().or(args.worktree.as_deref()))
-            );
-        }
-        Ok((wt_path, wt_branch, effective_dir, repo_path, fresh_worktree, emit_gitbutler_setup_hint))
-    })();
-    let (wt_path, wt_branch, effective_dir, repo_path, fresh_worktree, emit_gitbutler_setup_hint) = match worktree_setup {
-        Ok(paths) => paths,
+    let mut task = pending_task(args, &agent_setup, &task_id, &log_path, explicit_repo_path.clone(), caller);
+    apply_category_and_result_defaults(args, &mut task, had_explicit_result_file);
+    for warning in validate_dispatch(args, &agent_setup.agent_kind) {
+        aid_warn!("[aid] Warning: {warning}");
+    }
+    insert_task_claiming_id(store, &mut task, &mut task_id, &mut log_path, explicit_id)?;
+    let setup = match setup_worktree(args, detected_project.as_ref(), &agent_setup, &task_id, explicit_repo_path.as_deref()) {
+        Ok(setup) => setup,
         Err(err) => {
-            let failed_task = Task {
-                id: task_id.clone(),
-                agent: agent_setup.agent_kind,
-                custom_agent_name: agent_setup.custom_agent_name.clone(),
-                prompt: args.prompt.clone(),
-                resolved_prompt: None,
-                category: None,
-                status: TaskStatus::Failed,
-                parent_task_id: args.parent_task_id.clone(),
-                workgroup_id: args.group.clone(),
-                caller_kind: caller.as_ref().map(|item| item.kind.clone()),
-                caller_session_id: caller.as_ref().map(|item| item.session_id.clone()),
-                agent_session_id: None,
-                repo_path: explicit_repo_path.clone(),
-                worktree_path: None,
-                worktree_branch: args.worktree.clone(),
-                start_sha: None,
-                log_path: Some(log_path.to_string_lossy().to_string()),
-                output_path: args.output.clone(),
-                tokens: None,
-                prompt_tokens: None,
-                duration_ms: Some(0),
-                model: agent_setup.effective_model.clone(),
-                cost_usd: None,
-                exit_code: None,
-                created_at: Local::now(),
-                completed_at: Some(Local::now()),
-                verify: args.verify.clone(),
-                verify_status: VerifyStatus::Skipped,
-                pending_reason: None,
-                read_only: args.read_only,
-                budget: args.budget,
-                audit_verdict: None,
-                audit_report_path: None,
-                delivery_assessment: None,
-            };
-            let _ = store.insert_task(&failed_task);
-            run_prompt::insert_phase_error_event(
-                store,
-                &task_id,
-                "worktree setup",
-                &err.to_string(),
-                None,
-            );
+            fail_claimed_task(store, &task_id, agent_setup.effective_model.as_deref(), &err)?;
             return Err(err);
         }
     };
-    let mut task = Task {
-        id: task_id.clone(),
-        agent: agent_setup.agent_kind,
-        custom_agent_name: agent_setup.custom_agent_name.clone(),
-        prompt: args.prompt.clone(),
-        resolved_prompt: None,
-        category: None,
-        status: TaskStatus::Pending,
-        parent_task_id: args.parent_task_id.clone(),
-        workgroup_id: args.group.clone(),
+    if let Err(err) = persist_worktree_setup(store, &task_id, &mut task, &setup) {
+        clear_worktree_lock(setup.wt_path.as_deref());
+        fail_claimed_task(store, &task_id, agent_setup.effective_model.as_deref(), &err)?;
+        return Err(err);
+    }
+    if setup.emit_gitbutler_setup_hint {
+        super::run_dispatch_resolve::insert_gitbutler_setup_hint(store, &task_id);
+    }
+    prepare_worktree_deps(store, args, &task_id, &agent_setup, &setup)?;
+    if should_auto_result_file(args, had_explicit_result_file) {
+        let result_file = crate::cmd::report_mode::task_result_file(task_id.as_str());
+        args.result_file = Some(result_file.clone());
+        aid_info!("[aid] Audit report mode: auto-set --result-file {result_file}");
+    }
+    Ok(prepared_dispatch(detected_project, agent_setup, task_id, task, log_path, workgroup, setup))
+}
+
+fn initial_task_id(args: &RunArgs) -> Result<TaskId> {
+    match args.existing_task_id.clone() {
+        Some(id) => {
+            crate::sanitize::validate_task_id(id.as_str())?;
+            Ok(id)
+        }
+        None => Ok(TaskId::generate()),
+    }
+}
+
+fn pending_task(
+    args: &RunArgs,
+    agent_setup: &AgentSetup,
+    task_id: &TaskId,
+    log_path: &Path,
+    repo_path: Option<String>,
+    caller: Option<session::CallerSession>,
+) -> Task {
+    Task {
+        id: task_id.clone(), agent: agent_setup.agent_kind, custom_agent_name: agent_setup.custom_agent_name.clone(),
+        prompt: args.prompt.clone(), resolved_prompt: None, category: None, status: TaskStatus::Pending,
+        parent_task_id: args.parent_task_id.clone(), workgroup_id: args.group.clone(),
         caller_kind: caller.as_ref().map(|item| item.kind.clone()),
         caller_session_id: caller.as_ref().map(|item| item.session_id.clone()),
-        agent_session_id: None,
-        repo_path: repo_path.clone(),
-        worktree_path: wt_path.clone(),
-        worktree_branch: wt_branch,
-        start_sha: None,
-        log_path: Some(log_path.to_string_lossy().to_string()),
-        output_path: args.output.clone(),
-        tokens: None,
-        prompt_tokens: None,
-        duration_ms: None,
-        model: agent_setup.effective_model.clone(),
-        cost_usd: None,
-        exit_code: None,
-        created_at: Local::now(),
-        completed_at: None,
-        verify: args.verify.clone(),
-        verify_status: VerifyStatus::Skipped,
-        pending_reason: None,
-        read_only: args.read_only,
-        budget: args.budget,
-        audit_verdict: None,
-        audit_report_path: None,
+        agent_session_id: None, repo_path, worktree_path: None, worktree_branch: None, start_sha: None,
+        log_path: Some(log_path.to_string_lossy().to_string()), output_path: args.output.clone(),
+        tokens: None, prompt_tokens: None, duration_ms: None, model: agent_setup.effective_model.clone(),
+        cost_usd: None, exit_code: None, created_at: Local::now(), completed_at: None,
+        verify: args.verify.clone(), verify_status: VerifyStatus::Skipped, pending_reason: None,
+        read_only: args.read_only, budget: args.budget, audit_verdict: None, audit_report_path: None,
         delivery_assessment: None,
-    };
+    }
+}
+
+fn apply_category_and_result_defaults(args: &mut RunArgs, task: &mut Task, had_explicit_result_file: bool) {
     let normalized_prompt = task.prompt.trim().to_lowercase();
     let profile = agent::classifier::classify(
         &task.prompt,
@@ -200,98 +141,157 @@ pub(super) fn prepare_dispatch(store: &Arc<Store>, args: &mut RunArgs) -> Result
     );
     let report_output = crate::cmd::report_mode::apply_defaults(args, profile.category);
     args.audit_report_mode = crate::cmd::report_mode::skips_dirty_enforcement(&args.prompt, args.read_only, profile.category);
-    let auto_result_file = report_output
-        && !had_explicit_result_file
-        && args.output.is_none()
-        && args.result_file.as_deref() == Some(crate::cmd::report_mode::DEFAULT_AUDIT_RESULT_FILE);
+    if report_output && !had_explicit_result_file && args.output.is_none() {
+        args.result_file = Some(crate::cmd::report_mode::DEFAULT_AUDIT_RESULT_FILE.to_string());
+    }
     task.category = Some(profile.category.label().to_string());
-    for warning in validate_dispatch(args, &agent_setup.agent_kind) {
-        aid_warn!("[aid] Warning: {warning}");
-    }
-    if args.existing_task_id.is_some() {
-        match resolve_id_conflict(store, task_id.as_str())? {
-            IdConflict::None => store.insert_task(&task)?,
-            IdConflict::ReplaceWaiting => store.replace_waiting_task(&task)?,
-            IdConflict::Running => {
-                anyhow::bail!(
-                    "Task '{}' is still running. Stop it first: aid stop {}",
-                    task_id, task_id
-                );
-            }
-            IdConflict::AutoSuffix(new_id) => {
-                aid_info!("[aid] ID '{}' already exists, using '{}'", task_id, new_id);
-                task_id = TaskId(new_id);
-                log_path = paths::log_path(task_id.as_str());
-                task.id = task_id.clone();
-                task.log_path = Some(log_path.to_string_lossy().to_string());
-                // Re-key the worktree lock: it was acquired with the pre-suffix ID
-                // before conflict resolution, so its owner field is now stale.
-                if let Some(ref wt) = wt_path {
-                    crate::worktree::write_worktree_lock(Path::new(wt), task_id.as_str());
-                }
-                store.insert_task(&task)?;
-            }
+}
+
+fn should_auto_result_file(args: &RunArgs, had_explicit_result_file: bool) -> bool {
+    !had_explicit_result_file
+        && args.output.is_none()
+        && args.result_file.as_deref() == Some(crate::cmd::report_mode::DEFAULT_AUDIT_RESULT_FILE)
+}
+
+fn setup_worktree(
+    args: &mut RunArgs,
+    detected_project: Option<&ProjectConfig>,
+    agent_setup: &AgentSetup,
+    task_id: &TaskId,
+    explicit_repo_path: Option<&str>,
+) -> Result<WorktreeSetup> {
+    let (wt_path, wt_branch, effective_dir, resolved_repo, fresh_worktree) =
+        run_prompt::resolve_worktree_paths(args, explicit_repo_path)?;
+    let repo_path = resolved_repo.or_else(|| explicit_repo_path.map(str::to_string));
+    let mut lock = WorktreeLockGuard::new();
+    if let Some(ref wt) = wt_path {
+        if let Err(holder) = crate::worktree::try_acquire_worktree_lock(Path::new(wt), task_id.as_str()) {
+            anyhow::bail!("Worktree {wt} is locked by task {holder} — concurrent access prevented. Use separate worktree names for parallel tasks.");
         }
-    } else {
-        store.insert_task(&task)?;
+        lock.hold(wt);
     }
-    if emit_gitbutler_setup_hint {
-        super::run_dispatch_resolve::insert_gitbutler_setup_hint(store, &task_id);
+    let emit_gitbutler_setup_hint = configure_gitbutler(args, detected_project, agent_setup, wt_path.as_deref(), repo_path.as_deref());
+    sync_context_files(args, wt_path.as_deref(), repo_path.as_deref());
+    ensure_effective_dir(effective_dir.as_deref(), wt_path.as_deref(), wt_branch.as_deref().or(args.worktree.as_deref()))?;
+    lock.disarm();
+    Ok(WorktreeSetup { wt_path, wt_branch, effective_dir, repo_path, fresh_worktree, emit_gitbutler_setup_hint })
+}
+
+fn configure_gitbutler(
+    args: &mut RunArgs, detected_project: Option<&ProjectConfig>,
+    agent_setup: &AgentSetup, wt_path: Option<&str>, repo_path: Option<&str>,
+) -> bool {
+    if std::env::var("AID_GITBUTLER").map(|value| value == "0").unwrap_or(false) {
+        return false;
     }
-    if !args.dry_run
-        && let (Some(wt), Some(repo)) = (wt_path.as_deref(), repo_path.as_deref())
-        && let Err(err) = crate::worktree_deps::prepare_worktree_dependencies(
-            store,
-            &task_id,
-            Path::new(repo),
-            Path::new(wt),
-            args.setup.as_deref(),
-            args.link_deps,
-            crate::idle_timeout::idle_timeout_secs_from_env(args.env.as_ref()),
-            fresh_worktree,
-        )
-    {
-        crate::worktree::clear_worktree_lock(Path::new(wt));
-        store.complete_task_atomic(
-            TaskCompletionUpdate {
-                id: task_id.as_str(),
-                status: TaskStatus::Failed,
-                tokens: None,
-                duration_ms: 0,
-                model: agent_setup.effective_model.as_deref(),
-                cost_usd: None,
-                exit_code: None,
-            },
-            &TaskEvent {
-                task_id: task_id.clone(),
-                timestamp: Local::now(),
-                event_kind: EventKind::Error,
-                detail: format!("Failed during worktree setup: {err}"),
-                metadata: None,
-            },
-        )?;
+    let (Some(wt), Some(project), Some(repo)) = (wt_path, detected_project, repo_path) else {
+        return false;
+    };
+    let worktree = Path::new(wt);
+    let plan = crate::gitbutler::task_worktree_integration_plan(
+        Path::new(repo), worktree, project.gitbutler_mode(), agent_setup.agent_kind.as_str(),
+    );
+    if plan.install_claude_hooks {
+        if let Err(err) = crate::gitbutler::install_claude_hooks(worktree) {
+            aid_warn!("[aid] gitbutler: failed to install claude hooks: {err}");
+        }
+    } else if let Some(command) = plan.on_done_command {
+        args.on_done = Some(match args.on_done.take() {
+            Some(existing) if !existing.trim().is_empty() => format!("{existing} && {command}"),
+            _ => command,
+        });
+    }
+    plan.emit_setup_hint
+}
+
+fn sync_context_files(args: &RunArgs, wt_path: Option<&str>, repo_path: Option<&str>) {
+    let (Some(wt), Some(repo)) = (wt_path, repo_path) else { return; };
+    let context_files: Vec<String> = args.context.iter().map(|spec| context_file_from_spec(spec)).collect();
+    let synced = crate::worktree::sync_context_files_into_worktree(Path::new(repo), Path::new(wt), &context_files);
+    if !synced.is_empty() {
+        aid_info!("[aid] Synced {} context file(s) into worktree: {}", synced.len(), synced.join(", "));
+    }
+}
+
+fn ensure_effective_dir(dir: Option<&str>, wt_path: Option<&str>, branch: Option<&str>) -> Result<()> {
+    if wt_path.is_some()
+        && let Some(dir) = dir
+        && !Path::new(dir).is_dir() {
+            anyhow::bail!("{}", stale_worktree_dir_error(dir, branch));
+        }
+    Ok(())
+}
+
+fn persist_worktree_setup(store: &Store, task_id: &TaskId, task: &mut Task, setup: &WorktreeSetup) -> Result<()> {
+    task.repo_path = setup.repo_path.clone();
+    task.worktree_path = setup.wt_path.clone();
+    task.worktree_branch = setup.wt_branch.clone();
+    store.update_task_worktree(
+        task_id.as_str(),
+        task.repo_path.as_deref(),
+        task.worktree_path.as_deref(),
+        task.worktree_branch.as_deref(),
+    )
+}
+
+fn prepare_worktree_deps(
+    store: &Arc<Store>,
+    args: &RunArgs,
+    task_id: &TaskId,
+    agent_setup: &AgentSetup,
+    setup: &WorktreeSetup,
+) -> Result<()> {
+    if args.dry_run { return Ok(()); }
+    let (Some(wt), Some(repo)) = (setup.wt_path.as_deref(), setup.repo_path.as_deref()) else {
+        return Ok(());
+    };
+    if let Err(err) = crate::worktree_deps::prepare_worktree_dependencies(
+        store, task_id, Path::new(repo), Path::new(wt), args.setup.as_deref(), args.link_deps,
+        crate::idle_timeout::idle_timeout_secs_from_env(args.env.as_ref()), setup.fresh_worktree,
+    ) {
+        clear_worktree_lock(Some(wt));
+        fail_claimed_task(store, task_id, agent_setup.effective_model.as_deref(), &err)?;
         return Err(err);
     }
-    if auto_result_file {
-        let result_file = crate::cmd::report_mode::task_result_file(task_id.as_str());
-        args.result_file = Some(result_file.clone());
-        aid_info!("[aid] Audit report mode: auto-set --result-file {result_file}");
+    Ok(())
+}
+
+fn clear_worktree_lock(wt_path: Option<&str>) {
+    if let Some(wt) = wt_path {
+        crate::worktree::clear_worktree_lock(Path::new(wt));
     }
-    Ok(PreparedDispatch {
-        detected_project,
-        agent_kind: agent_setup.agent_kind,
+}
+
+fn fail_claimed_task(store: &Store, task_id: &TaskId, model: Option<&str>, err: &anyhow::Error) -> Result<()> {
+    store.complete_task_atomic(
+        TaskCompletionUpdate {
+            id: task_id.as_str(), status: TaskStatus::Failed, tokens: None, duration_ms: 0,
+            model, cost_usd: None, exit_code: None,
+        },
+        &TaskEvent {
+            task_id: task_id.clone(), timestamp: Local::now(), event_kind: EventKind::Error,
+            detail: format!("Failed during worktree setup: {err}"), metadata: None,
+        },
+    )
+}
+
+fn prepared_dispatch(
+    detected_project: Option<ProjectConfig>,
+    agent_setup: AgentSetup,
+    task_id: TaskId,
+    task: Task,
+    log_path: PathBuf,
+    workgroup: Option<Workgroup>,
+    setup: WorktreeSetup,
+) -> PreparedDispatch {
+    PreparedDispatch {
+        detected_project, agent_kind: agent_setup.agent_kind,
         agent_display_name: agent_setup.agent_display_name,
         requested_skills: agent_setup.requested_skills,
-        effective_model: agent_setup.effective_model,
-        budget_active: agent_setup.budget_active,
-        agent: agent_setup.agent,
-        task_id,
-        task,
-        log_path,
-        workgroup,
-        repo_path,
-        wt_path,
-        effective_dir,
-    })
+        effective_model: agent_setup.effective_model, budget_active: agent_setup.budget_active,
+        agent: agent_setup.agent, task_id, task, log_path, workgroup,
+        repo_path: setup.repo_path, wt_path: setup.wt_path, effective_dir: setup.effective_dir,
+    }
 }
+
 #[cfg(test)] #[path = "run_dispatch_prepare_tests.rs"] mod tests;

--- a/src/cmd/run_dispatch_prepare_tests.rs
+++ b/src/cmd/run_dispatch_prepare_tests.rs
@@ -3,7 +3,79 @@
 // Deps: super::prepare_dispatch, crate::store, RunArgs.
 
 use super::*;
+use chrono::Local;
+use std::path::Path;
+use std::process::Command;
 use std::sync::Arc;
+
+fn test_task(id: &str) -> Task {
+    Task {
+        id: TaskId(id.to_string()),
+        agent: AgentKind::Codex,
+        custom_agent_name: None,
+        prompt: "seed".to_string(),
+        resolved_prompt: None,
+        category: None,
+        status: TaskStatus::Pending,
+        parent_task_id: None,
+        workgroup_id: None,
+        caller_kind: None,
+        caller_session_id: None,
+        agent_session_id: None,
+        repo_path: None,
+        worktree_path: None,
+        worktree_branch: None,
+        start_sha: None,
+        log_path: None,
+        output_path: None,
+        tokens: None,
+        prompt_tokens: None,
+        duration_ms: None,
+        model: None,
+        cost_usd: None,
+        exit_code: None,
+        created_at: Local::now(),
+        completed_at: None,
+        verify: None,
+        verify_status: VerifyStatus::Skipped,
+        pending_reason: None,
+        read_only: false,
+        budget: false,
+        audit_verdict: None,
+        audit_report_path: None,
+        delivery_assessment: None,
+    }
+}
+
+fn git(repo_dir: &Path, args: &[&str]) {
+    assert!(Command::new("git")
+        .args(["-C", &repo_dir.to_string_lossy()])
+        .args(args)
+        .status()
+        .unwrap()
+        .success());
+}
+
+fn git_output(repo_dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(["-C", &repo_dir.to_string_lossy()])
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn init_repo() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    git(repo.path(), &["init", "-b", "main"]);
+    git(repo.path(), &["config", "user.email", "test@example.com"]);
+    git(repo.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    git(repo.path(), &["add", "base.txt"]);
+    git(repo.path(), &["commit", "-m", "init"]);
+    repo
+}
 
 #[test]
 fn report_mode_dirty_skip_uses_narrow_predicate() {
@@ -29,6 +101,62 @@ fn report_mode_dirty_skip_uses_narrow_predicate() {
         false,
         TaskCategory::Research,
     ));
+}
+
+#[test]
+fn generated_id_collision_retries_and_dispatch_succeeds() {
+    let store = Arc::new(Store::open_memory().unwrap());
+    store.insert_task(&test_task("t-00000001")).unwrap();
+    TaskId::set_generate_sequence_for_tests(&["t-00000001", "t-00000002"]);
+    let mut args = RunArgs {
+        agent_name: "codex".to_string(),
+        prompt: "Investigate a concrete task routing bug.".to_string(),
+        ..Default::default()
+    };
+
+    let prepared = prepare_dispatch(&store, &mut args).unwrap();
+
+    assert_eq!(prepared.task_id.as_str(), "t-00000002");
+    assert!(store.get_task("t-00000001").unwrap().is_some());
+    assert!(store.get_task("t-00000002").unwrap().is_some());
+}
+
+#[test]
+fn generated_id_exhaustion_does_not_reset_worktree_branch() {
+    let _permit = crate::test_subprocess::acquire();
+    let repo = init_repo();
+    let store = Arc::new(Store::open_memory().unwrap());
+    let branch = "fix/collision-branch";
+    git(repo.path(), &["checkout", "-b", branch]);
+    std::fs::write(repo.path().join("sentinel.txt"), "keep\n").unwrap();
+    git(repo.path(), &["add", "sentinel.txt"]);
+    git(repo.path(), &["commit", "-m", "sentinel"]);
+    let branch_before = git_output(repo.path(), &["rev-parse", branch]);
+    git(repo.path(), &["checkout", "main"]);
+    let ids = [
+        "t-dead0001", "t-dead0002", "t-dead0003", "t-dead0004",
+        "t-dead0005", "t-dead0006", "t-dead0007", "t-dead0008",
+    ];
+    for id in ids {
+        store.insert_task(&test_task(id)).unwrap();
+    }
+    TaskId::set_generate_sequence_for_tests(&ids);
+    let mut args = RunArgs {
+        agent_name: "codex".to_string(),
+        prompt: "Investigate a concrete task routing bug.".to_string(),
+        repo_root: Some(repo.path().display().to_string()),
+        worktree: Some(branch.to_string()),
+        base_branch: Some("main".to_string()),
+        ..Default::default()
+    };
+
+    let err = match prepare_dispatch(&store, &mut args) {
+        Ok(_) => panic!("dispatch should fail after generated ID retries are exhausted"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("failed to allocate unique task ID"));
+    assert_eq!(git_output(repo.path(), &["rev-parse", branch]), branch_before);
 }
 
 #[test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -32,7 +32,7 @@ pub fn is_valid_task_id(id: &str) -> bool {
 }
 
 /// Validate a workgroup ID: must start with `wg-` followed by safe characters.
-/// Accepts both generated hex IDs (wg-a3f1) and custom names (wg-my-feature).
+/// Accepts both generated hex IDs (wg-a3f1b2c4) and custom names (wg-my-feature).
 pub fn validate_workgroup_id(id: &str) -> Result<()> {
     if id.len() < 4 || !id.starts_with("wg-") {
         bail!("Invalid workgroup ID '{id}': must start with 'wg-'");
@@ -151,9 +151,9 @@ mod tests {
 
     #[test]
     fn valid_task_ids() {
-        assert!(validate_task_id("t-a3f1").is_ok());
-        assert!(validate_task_id("t-0000").is_ok());
-        assert!(validate_task_id("t-ffff").is_ok());
+        assert!(validate_task_id("t-a3f1b2c4").is_ok());
+        assert!(validate_task_id("t-00000000").is_ok());
+        assert!(validate_task_id("t-ffffffff").is_ok());
         assert!(validate_task_id("audit-utilcap").is_ok());
         assert!(validate_task_id("fix-lb-cache").is_ok());
         assert!(validate_task_id("my_task_1").is_ok());
@@ -183,8 +183,8 @@ mod tests {
 
     #[test]
     fn valid_workgroup_ids() {
-        assert!(validate_workgroup_id("wg-a3f1").is_ok());
-        assert!(validate_workgroup_id("wg-0000").is_ok());
+        assert!(validate_workgroup_id("wg-a3f1b2c4").is_ok());
+        assert!(validate_workgroup_id("wg-00000000").is_ok());
         assert!(validate_workgroup_id("wg-custom").is_ok());
         assert!(validate_workgroup_id("wg-my-feature").is_ok());
         assert!(validate_workgroup_id("wg-shared").is_ok());

--- a/src/store/mutations.rs
+++ b/src/store/mutations.rs
@@ -243,6 +243,20 @@ impl Store {
         Ok(())
     }
 
+    pub(crate) fn update_task_worktree(
+        &self,
+        id: &str,
+        repo_path: Option<&str>,
+        worktree_path: Option<&str>,
+        worktree_branch: Option<&str>,
+    ) -> Result<()> {
+        self.db().execute(
+            "UPDATE tasks SET repo_path = ?1, worktree_path = ?2, worktree_branch = ?3 WHERE id = ?4",
+            params![repo_path, worktree_path, worktree_branch, id],
+        )?;
+        Ok(())
+    }
+
     pub fn update_start_sha(&self, id: &str, start_sha: &str) -> Result<()> {
         self.db().execute(
             "UPDATE tasks SET start_sha = ?1 WHERE id = ?2",

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@
 use rand::Rng;
 use serde::Serialize;
 use std::fmt;
+#[cfg(test)]
+use std::{cell::RefCell, collections::VecDeque};
 
 #[path = "types/agent.rs"]
 mod agent;
@@ -26,18 +28,34 @@ pub use self::memory::{Memory, MemoryId, MemoryTier, MemoryType};
 pub use self::status::{EventKind, PendingReason, TaskStatus, VerifyStatus};
 pub use self::task::{CompletionInfo, Finding, Task, TaskEvent, TaskFilter, Workgroup};
 
-/// Short hex ID prefixed with "t-", e.g. "t-a3f1"
+/// Short hex ID prefixed with "t-", e.g. "t-a3f1b2c4"
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TaskId(pub String);
 
+#[cfg(test)]
+thread_local! {
+    static TASK_ID_SEQUENCE: RefCell<VecDeque<String>> = RefCell::new(VecDeque::new());
+}
+
 impl TaskId {
     pub fn generate() -> Self {
-        let val: u16 = rand::rng().random();
-        Self(format!("t-{val:04x}"))
+        #[cfg(test)]
+        if let Some(id) = TASK_ID_SEQUENCE.with(|ids| ids.borrow_mut().pop_front()) {
+            return Self(id);
+        }
+        let val: u32 = rand::rng().random();
+        Self(format!("t-{val:08x}"))
     }
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_generate_sequence_for_tests(ids: &[&str]) {
+        TASK_ID_SEQUENCE.with(|sequence| {
+            *sequence.borrow_mut() = ids.iter().map(|id| id.to_string()).collect();
+        });
     }
 }
 
@@ -47,14 +65,14 @@ impl fmt::Display for TaskId {
     }
 }
 
-/// Short hex ID prefixed with "wg-", e.g. "wg-a3f1"
+/// Short hex ID prefixed with "wg-", e.g. "wg-a3f1b2c4"
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WorkgroupId(pub String);
 
 impl WorkgroupId {
     pub fn generate() -> Self {
-        let val: u16 = rand::rng().random();
-        Self(format!("wg-{val:04x}"))
+        let val: u32 = rand::rng().random();
+        Self(format!("wg-{val:08x}"))
     }
 
     pub fn as_str(&self) -> &str {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -51,6 +51,20 @@ fn agent_display_name_returns_custom_name() {
 }
 
 #[test]
+fn generated_ids_use_32_bit_hex() {
+    TaskId::set_generate_sequence_for_tests(&[]);
+    assert_eq!(TaskId::generate().as_str().len(), 10);
+    assert_eq!(WorkgroupId::generate().as_str().len(), 11);
+}
+
+#[test]
+fn task_id_generate_can_be_seeded_for_collision_tests() {
+    TaskId::set_generate_sequence_for_tests(&["t-collision", "t-retry"]);
+    assert_eq!(TaskId::generate().as_str(), "t-collision");
+    assert_eq!(TaskId::generate().as_str(), "t-retry");
+}
+
+#[test]
 fn agent_display_name_defaults_for_custom() {
     let task = sample_task(AgentKind::Custom, None);
     assert_eq!(task.agent_display_name(), "custom");

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -27,8 +27,10 @@ pub(crate) use baseline::{baseline_contains, extract_baseline_path, extract_base
 pub use path::{aid_worktree_path, aid_worktree_root, is_aid_managed_worktree_path};
 pub use state::{
     branch_has_commits_ahead_of_main, clear_worktree_lock, process_alive_check,
-    try_acquire_worktree_lock, worktree_changed_files, write_worktree_lock,
+    try_acquire_worktree_lock, worktree_changed_files,
 };
+#[cfg(test)]
+pub use state::write_worktree_lock;
 #[cfg(test)]
 pub use state::check_worktree_lock;
 pub(crate) use completion::cleanup_completed_worktree;


### PR DESCRIPTION
Fixes #134.

Task ID collisions were not one bug but a **5-layer stack**. This closes all of them.

## Layers fixed

| # | Layer | Fix |
|---|-------|-----|
| 1 | 16-bit ID space (`t-{u16:04x}`, 65 536 values) — collision odds ≈ N/65536 | Widened `TaskId` **and** `WorkgroupId` to u32 hex (`t-`/`wg-{:08x}`) |
| 2 | Regenerate-and-retry existed but was gated behind `existing_task_id.is_some()`; the generated-ID path called `insert_task` raw | New `run_dispatch_claim.rs`: insert-and-on-conflict-retry (bounded, 8 attempts), PK conflict detected via rusqlite extended code `1555` |
| 3 | **Data-loss class:** branch-mutating worktree setup (`git branch -f`) ran *before* the DB insert; a UNIQUE failure left the target branch reset to base HEAD, orphaning the prior commit | Reordered: the task row is committed (claiming the ID) **before** any worktree/branch mutation. On collision the retry stays entirely inside the insert loop — no git op runs |
| 4 | Asymmetric failure handling: worktree-setup *error* recorded a Failed task, but insert-failure-after-setup left no record/cleanup | Every post-insert error path now calls `fail_claimed_task` (atomic Failed + error event) |
| 5 | Worktree lock leaked on insert failure (cleared only on the deps path) | RAII `WorktreeLockGuard` + explicit clears on all error paths; lock is now acquired *after* the ID is claimed, so the AutoSuffix lock re-key is gone |

## Tests
- `generated_id_collision_retries_and_dispatch_succeeds` — seeded-ID collision, dispatch succeeds with a different ID
- `generated_id_exhaustion_does_not_reset_worktree_branch` — when all 8 IDs collide, `git rev-parse <branch>` is unchanged before/after (proves no branch reset)
- thread_local test hook (`set_generate_sequence_for_tests`), `#[cfg(test)]`-gated, for deterministic collision injection

## Board rendering
Widening IDs to 8 hex made task IDs 10 chars and group IDs 11 chars; widened the ID / Parent / Group columns in `board.rs` so rows stay aligned.

## Audit
Cross-audited by two independent agents (gemini + opencode/glm) against an adversarial checklist covering all 5 layers — both **SHIP**. The highest-risk item (the `anyhow → rusqlite::Error` downcast in the retry) was verified correct end-to-end; `1555` confirmed as `SQLITE_CONSTRAINT_PRIMARYKEY` (matches the runtime error in the original report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
