### PR TITLE
fix(sandbox): mount linked-worktree git dirs in container --sandbox mode (#127)

### DIFF
--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -7,8 +7,7 @@ mod output_classifier;
 use anyhow::{bail, Result};
 use chrono::Local;
 use serde_json::{json, Map, Value};
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -18,6 +17,7 @@ use super::RunOpts;
 use crate::rate_limit;
 use crate::templates;
 use crate::types::*;
+use crate::worktree_layout::{read_commondir, resolve_worktree_gitdir};
 
 /// Parsed codex CLI version (major, minor, patch).
 /// Cached via OnceLock so `codex --version` runs at most once.
@@ -150,56 +150,6 @@ impl super::Agent for CodexAgent {
     }
 }
 
-fn resolve_worktree_gitdir(dir: &Path) -> Option<PathBuf> {
-    let git_path = dir.join(".git");
-    let gitfile = worktree_gitfile(&git_path)?;
-    let content = match fs::read_to_string(&gitfile) {
-        Ok(content) => content,
-        Err(err) => {
-            eprintln!("warning: failed to read codex worktree gitfile: {err}");
-            return None;
-        }
-    };
-    let Some(raw_path) = content.lines().find_map(|line| line.strip_prefix("gitdir:")) else {
-        eprintln!("warning: failed to parse codex worktree gitfile: {}", gitfile.display());
-        return None;
-    };
-    let path = Path::new(raw_path.trim());
-    let resolved = if path.is_absolute() { path.to_path_buf() } else { dir.join(path) };
-    match fs::canonicalize(resolved) {
-        Ok(path) => Some(path),
-        Err(err) => {
-            eprintln!("warning: failed to resolve codex worktree gitdir: {err}");
-            None
-        }
-    }
-}
-
-fn worktree_gitfile(git_path: &Path) -> Option<PathBuf> {
-    let (gitfile, metadata) = resolve_git_path(git_path)?;
-    if metadata.is_dir() {
-        return None;
-    }
-    if metadata.is_file() {
-        return Some(gitfile);
-    }
-    eprintln!(
-        "warning: codex .git path is neither file nor directory: {}",
-        gitfile.display()
-    );
-    None
-}
-
-fn resolve_git_path(git_path: &Path) -> Option<(PathBuf, fs::Metadata)> {
-    let metadata = fs::symlink_metadata(git_path).ok()?;
-    if metadata.file_type().is_symlink() {
-        let resolved = fs::canonicalize(git_path).ok()?;
-        let metadata = fs::metadata(&resolved).ok()?;
-        return Some((resolved, metadata));
-    }
-    Some((git_path.to_path_buf(), metadata))
-}
-
 fn writable_roots_config(path: &Path) -> Option<String> {
     let mut roots = vec![toml::Value::String(path.to_str()?.to_string())];
     if let Some(commondir) =
@@ -209,17 +159,6 @@ fn writable_roots_config(path: &Path) -> Option<String> {
     }
     let value = toml::Value::Array(roots);
     Some(format!("sandbox_workspace_write.writable_roots={value}"))
-}
-
-fn read_commondir(gitdir: &Path) -> Option<PathBuf> {
-    let content = fs::read_to_string(gitdir.join("commondir")).ok()?;
-    let path = Path::new(content.trim());
-    let resolved = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        gitdir.join(path)
-    };
-    fs::canonicalize(resolved).ok()
 }
 
 fn parse_item_event(

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ mod rate_limit;
 mod repo_root;
 pub(crate) mod sanitize;
 mod sandbox;
+#[cfg(test)]
+mod sandbox_tests;
 mod session;
 mod shared_dir;
 mod skills;
@@ -86,6 +88,7 @@ mod workgroup;
 mod worktree_gc;
 mod worktree_deps;
 mod worktree;
+mod worktree_layout;
 mod cli;
 
 use crate::cli::{Cli, Commands};

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -129,9 +129,13 @@ fn worktree_git_mounts(cwd: &str) -> Vec<(String, String)> {
         return Vec::new();
     };
     let mut mounts = Vec::new();
-    push_git_mount(&mut mounts, &cwd_mount, &gitdir);
     if let Some(commondir) = read_commondir(&gitdir) {
         push_git_mount(&mut mounts, &cwd_mount, &commondir);
+        if !gitdir.starts_with(&commondir) {
+            push_git_mount(&mut mounts, &cwd_mount, &gitdir);
+        }
+    } else {
+        push_git_mount(&mut mounts, &cwd_mount, &gitdir);
     }
     mounts
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,6 +4,7 @@
 use std::process::{Command, Stdio};
 
 use crate::types::AgentKind;
+use crate::worktree_layout::{read_commondir, resolve_worktree_gitdir};
 
 const CONTAINER_BIN: &str = "container";
 const SANDBOX_IMAGE: &str = "aid-sandbox:latest";
@@ -55,11 +56,28 @@ pub fn wrap_command(
         wrapped.arg("--tmpfs").arg("/tmp");
     }
     if let Some(dir) = cwd.as_deref() {
-        wrapped.arg("-v").arg(format!("{dir}:{dir}"));
-        wrapped.arg("-w").arg(dir);
-        wrapped.current_dir(dir);
+        mount_workdir(&mut wrapped, dir);
     }
-    // Forward env vars explicitly set on the command
+    forward_command_envs(&mut wrapped, cmd);
+    forward_agent_envs(&mut wrapped, agent_kind);
+    mount_agent_home(&mut wrapped, agent_kind);
+    wrapped.arg("-e").arg("HOME=/root");
+    wrapped.arg(SANDBOX_IMAGE);
+    wrapped.arg(cmd.get_program());
+    wrapped.args(cmd.get_args());
+    wrapped
+}
+
+fn mount_workdir(wrapped: &mut Command, dir: &str) {
+    wrapped.arg("-v").arg(format!("{dir}:{dir}"));
+    for (host, container) in worktree_git_mounts(dir) {
+        wrapped.arg("-v").arg(format!("{host}:{container}"));
+    }
+    wrapped.arg("-w").arg(dir);
+    wrapped.current_dir(dir);
+}
+
+fn forward_command_envs(wrapped: &mut Command, cmd: &Command) {
     for (key, value) in cmd.get_envs() {
         if let Some(value) = value {
             wrapped.arg("-e").arg(format!(
@@ -69,13 +87,17 @@ pub fn wrap_command(
             ));
         }
     }
-    // Forward agent-specific API keys from host environment (inherit mode)
+}
+
+fn forward_agent_envs(wrapped: &mut Command, agent_kind: AgentKind) {
     for key in agent_env_keys(agent_kind) {
         if std::env::var_os(key).is_some() {
             wrapped.arg("-e").arg(*key);
         }
     }
-    // Mount agent config directories (auth, settings) from host
+}
+
+fn mount_agent_home(wrapped: &mut Command, agent_kind: AgentKind) {
     if let Some(home) = std::env::var_os("HOME") {
         let home = std::path::Path::new(&home);
         for subdir in agent_config_dirs(agent_kind) {
@@ -98,11 +120,37 @@ pub fn wrap_command(
                 .arg("AID_HOME=/root/.aid");
         }
     }
-    wrapped.arg("-e").arg("HOME=/root");
-    wrapped.arg(SANDBOX_IMAGE);
-    wrapped.arg(cmd.get_program());
-    wrapped.args(cmd.get_args());
-    wrapped
+}
+
+fn worktree_git_mounts(cwd: &str) -> Vec<(String, String)> {
+    let cwd_path = std::path::Path::new(cwd);
+    let cwd_mount = std::fs::canonicalize(cwd_path).unwrap_or_else(|_| cwd_path.to_path_buf());
+    let Some(gitdir) = resolve_worktree_gitdir(cwd_path) else {
+        return Vec::new();
+    };
+    let mut mounts = Vec::new();
+    push_git_mount(&mut mounts, &cwd_mount, &gitdir);
+    if let Some(commondir) = read_commondir(&gitdir) {
+        push_git_mount(&mut mounts, &cwd_mount, &commondir);
+    }
+    mounts
+}
+
+fn push_git_mount(
+    mounts: &mut Vec<(String, String)>,
+    cwd: &std::path::Path,
+    path: &std::path::Path,
+) {
+    if path.starts_with(cwd) {
+        return;
+    }
+    let Some(mount) = path.to_str().map(ToOwned::to_owned) else {
+        return;
+    };
+    if mounts.iter().any(|(host, _)| host == &mount) {
+        return;
+    }
+    mounts.push((mount.clone(), mount));
 }
 
 fn agent_env_keys(kind: AgentKind) -> &'static [&'static str] {
@@ -144,154 +192,4 @@ pub fn kill_container(task_id: &str) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{can_sandbox, wrap_command};
-    use crate::types::AgentKind;
-    use std::{
-        ffi::OsString,
-        fs,
-        process::Command,
-        sync::{Mutex, OnceLock},
-    };
-    use tempfile::tempdir;
-
-    fn args(cmd: &Command) -> Vec<String> {
-        cmd.get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect()
-    }
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    struct HomeGuard(Option<OsString>);
-
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(home) => unsafe {
-                    std::env::set_var("HOME", home);
-                },
-                None => unsafe {
-                    std::env::remove_var("HOME");
-                },
-            }
-        }
-    }
-
-    fn with_home<F>(dirs: &[&str], test: F)
-    where
-        F: FnOnce(),
-    {
-        let _guard = env_lock().lock().expect("env lock poisoned");
-        let temp = tempdir().expect("tempdir");
-        for dir in dirs {
-            fs::create_dir_all(temp.path().join(dir)).expect("create home subdir");
-        }
-        let original_home = std::env::var_os("HOME");
-        let _home_guard = HomeGuard(original_home);
-        unsafe {
-            std::env::set_var("HOME", temp.path());
-        }
-        test();
-    }
-
-    #[test]
-    fn cannot_sandbox_native_agents() {
-        assert!(!can_sandbox(AgentKind::OpenCode));
-        assert!(!can_sandbox(AgentKind::Copilot));
-        assert!(!can_sandbox(AgentKind::Cursor));
-        assert!(!can_sandbox(AgentKind::Droid));
-        assert!(!can_sandbox(AgentKind::Oz));
-        assert!(!can_sandbox(AgentKind::Claude));
-        assert!(!can_sandbox(AgentKind::Custom));
-        assert!(can_sandbox(AgentKind::Codex));
-    }
-
-    #[test]
-    fn wrap_command_builds_container_run() {
-        let mut cmd = Command::new("codex");
-        cmd.args(["exec", "ship it"]);
-
-        let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
-        let wrapped_args = args(&wrapped);
-
-        assert_eq!(wrapped.get_program().to_string_lossy(), "container");
-        assert!(wrapped_args.iter().any(|arg| arg == "run"));
-        assert!(wrapped_args.iter().any(|arg| arg == "--rm"));
-        assert!(wrapped_args.iter().any(|arg| arg == "--init"));
-        assert!(wrapped_args.iter().any(|arg| arg == "aid-sandbox:latest"));
-        assert_eq!(wrapped_args[wrapped_args.len() - 3], "codex");
-        assert_eq!(wrapped_args[wrapped_args.len() - 2], "exec");
-        assert_eq!(wrapped_args[wrapped_args.len() - 1], "ship it");
-    }
-
-    #[test]
-    fn wrap_command_forwards_env_vars() {
-        let mut cmd = Command::new("codex");
-        cmd.env("OPENAI_API_KEY", "test-key");
-
-        let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
-        let wrapped_args = args(&wrapped);
-
-        assert!(wrapped_args
-            .windows(2)
-            .any(|pair| pair == ["-e", "OPENAI_API_KEY=test-key"]));
-    }
-
-    #[test]
-    fn wrap_command_mounts_project_dir() {
-        with_home(&[".aid"], || {
-            let mut cmd = Command::new("codex");
-            cmd.current_dir("/tmp/project");
-
-            let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
-            let wrapped_args = args(&wrapped);
-
-            assert!(wrapped_args
-                .windows(2)
-                .any(|pair| pair == ["-v", "/tmp/project:/tmp/project"]));
-            assert!(wrapped_args
-                .windows(2)
-                .any(|pair| pair == ["-w", "/tmp/project"]));
-            assert!(wrapped_args
-                .windows(2)
-                .any(|pair| pair[0] == "-v" && pair[1].ends_with(":/root/.aid")));
-        });
-    }
-
-    #[test]
-    fn wrap_command_mounts_aid_home() {
-        with_home(&[".aid"], || {
-            let cmd = Command::new("codex");
-
-            let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
-            let wrapped_args = args(&wrapped);
-
-            assert!(wrapped_args
-                .windows(2)
-                .any(|pair| pair[0] == "-v" && pair[1].ends_with(":/root/.aid")));
-            assert!(wrapped_args
-                .windows(2)
-                .any(|pair| pair == ["-e", "AID_HOME=/root/.aid"]));
-        });
-    }
-
-    #[test]
-    fn wrap_command_readonly_adds_flag() {
-        let cmd = Command::new("codex");
-
-        let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, true);
-        let wrapped_args = args(&wrapped);
-
-        assert!(wrapped_args.iter().any(|arg| arg == "--read-only"));
-        assert!(wrapped_args
-            .windows(2)
-            .any(|pair| pair == ["--tmpfs", "/tmp"]));
-    }
 }

--- a/src/sandbox_tests.rs
+++ b/src/sandbox_tests.rs
@@ -1,0 +1,209 @@
+// Unit tests for container sandbox command wrapping.
+// Covers mount/env behavior for regular checkouts and linked git worktrees.
+
+use crate::sandbox::{can_sandbox, wrap_command};
+use crate::types::AgentKind;
+use std::{
+    ffi::OsString,
+    fs,
+    path::Path,
+    process::Command,
+    sync::{Mutex, OnceLock},
+};
+use tempfile::tempdir;
+
+fn args(cmd: &Command) -> Vec<String> {
+    cmd.get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn self_mount(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    format!("{path}:{path}")
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct HomeGuard(Option<OsString>);
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match self.0.take() {
+            Some(home) => unsafe {
+                std::env::set_var("HOME", home);
+            },
+            None => unsafe {
+                std::env::remove_var("HOME");
+            },
+        }
+    }
+}
+
+fn with_home<F>(dirs: &[&str], test: F)
+where
+    F: FnOnce(),
+{
+    let _guard = env_lock().lock().expect("env lock poisoned");
+    let temp = tempdir().expect("tempdir");
+    for dir in dirs {
+        fs::create_dir_all(temp.path().join(dir)).expect("create home subdir");
+    }
+    let original_home = std::env::var_os("HOME");
+    let _home_guard = HomeGuard(original_home);
+    unsafe {
+        std::env::set_var("HOME", temp.path());
+    }
+    test();
+}
+
+#[test]
+fn cannot_sandbox_native_agents() {
+    assert!(!can_sandbox(AgentKind::OpenCode));
+    assert!(!can_sandbox(AgentKind::Copilot));
+    assert!(!can_sandbox(AgentKind::Cursor));
+    assert!(!can_sandbox(AgentKind::Droid));
+    assert!(!can_sandbox(AgentKind::Oz));
+    assert!(!can_sandbox(AgentKind::Claude));
+    assert!(!can_sandbox(AgentKind::Custom));
+    assert!(can_sandbox(AgentKind::Codex));
+}
+
+#[test]
+fn wrap_command_builds_container_run() {
+    let mut cmd = Command::new("codex");
+    cmd.args(["exec", "ship it"]);
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+    let wrapped_args = args(&wrapped);
+
+    assert_eq!(wrapped.get_program().to_string_lossy(), "container");
+    assert!(wrapped_args.iter().any(|arg| arg == "run"));
+    assert!(wrapped_args.iter().any(|arg| arg == "--rm"));
+    assert!(wrapped_args.iter().any(|arg| arg == "--init"));
+    assert!(wrapped_args.iter().any(|arg| arg == "aid-sandbox:latest"));
+    assert_eq!(wrapped_args[wrapped_args.len() - 3], "codex");
+    assert_eq!(wrapped_args[wrapped_args.len() - 2], "exec");
+    assert_eq!(wrapped_args[wrapped_args.len() - 1], "ship it");
+}
+
+#[test]
+fn wrap_command_forwards_env_vars() {
+    let mut cmd = Command::new("codex");
+    cmd.env("OPENAI_API_KEY", "test-key");
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+    let wrapped_args = args(&wrapped);
+
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair == ["-e", "OPENAI_API_KEY=test-key"]));
+}
+
+#[test]
+fn wrap_command_mounts_project_dir() {
+    with_home(&[".aid"], || {
+        let mut cmd = Command::new("codex");
+        cmd.current_dir("/tmp/project");
+
+        let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+        let wrapped_args = args(&wrapped);
+
+        assert!(wrapped_args
+            .windows(2)
+            .any(|pair| pair == ["-v", "/tmp/project:/tmp/project"]));
+        assert!(wrapped_args
+            .windows(2)
+            .any(|pair| pair == ["-w", "/tmp/project"]));
+        assert!(wrapped_args
+            .windows(2)
+            .any(|pair| pair[0] == "-v" && pair[1].ends_with(":/root/.aid")));
+    });
+}
+
+#[test]
+fn wrap_command_mounts_linked_worktree_gitdirs() {
+    let temp = tempdir().expect("tempdir");
+    let worktree = temp.path().join("worktree");
+    let common = temp.path().join("common/.git");
+    let gitdir = common.join("worktrees/feature");
+    fs::create_dir_all(&worktree).expect("create worktree");
+    fs::create_dir_all(&gitdir).expect("create gitdir");
+    fs::write(
+        worktree.join(".git"),
+        "gitdir: ../common/.git/worktrees/feature\n",
+    )
+    .expect("write gitfile");
+    fs::write(gitdir.join("commondir"), "../..\n").expect("write commondir");
+    let gitdir = gitdir.canonicalize().expect("canonical gitdir");
+    let common = common.canonicalize().expect("canonical common");
+    let mut cmd = Command::new("codex");
+    cmd.current_dir(&worktree);
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+    let wrapped_args = args(&wrapped);
+    let gitdir_mount = self_mount(&gitdir);
+    let common_mount = self_mount(&common);
+
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair[0] == "-v" && pair[1] == gitdir_mount));
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair[0] == "-v" && pair[1] == common_mount));
+}
+
+#[test]
+fn wrap_command_skips_git_mounts_for_regular_checkout() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    let gitdir = repo.join(".git");
+    fs::create_dir_all(&gitdir).expect("create gitdir");
+    let mut cmd = Command::new("codex");
+    cmd.current_dir(&repo);
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+    let wrapped_args = args(&wrapped);
+    let repo_mount = self_mount(&repo);
+    let gitdir_mount = self_mount(&gitdir);
+
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair[0] == "-v" && pair[1] == repo_mount));
+    assert!(!wrapped_args
+        .windows(2)
+        .any(|pair| pair[0] == "-v" && pair[1] == gitdir_mount));
+}
+
+#[test]
+fn wrap_command_mounts_aid_home() {
+    with_home(&[".aid"], || {
+        let cmd = Command::new("codex");
+
+        let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+        let wrapped_args = args(&wrapped);
+
+        assert!(wrapped_args
+            .windows(2)
+            .any(|pair| pair[0] == "-v" && pair[1].ends_with(":/root/.aid")));
+        assert!(wrapped_args
+            .windows(2)
+            .any(|pair| pair == ["-e", "AID_HOME=/root/.aid"]));
+    });
+}
+
+#[test]
+fn wrap_command_readonly_adds_flag() {
+    let cmd = Command::new("codex");
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, true);
+    let wrapped_args = args(&wrapped);
+
+    assert!(wrapped_args.iter().any(|arg| arg == "--read-only"));
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair == ["--tmpfs", "/tmp"]));
+}

--- a/src/sandbox_tests.rs
+++ b/src/sandbox_tests.rs
@@ -148,12 +148,33 @@ fn wrap_command_mounts_linked_worktree_gitdirs() {
     let gitdir_mount = self_mount(&gitdir);
     let common_mount = self_mount(&common);
 
-    assert!(wrapped_args
+    assert!(!wrapped_args
         .windows(2)
         .any(|pair| pair[0] == "-v" && pair[1] == gitdir_mount));
     assert!(wrapped_args
         .windows(2)
         .any(|pair| pair[0] == "-v" && pair[1] == common_mount));
+}
+
+#[test]
+fn wrap_command_mounts_worktree_gitdir_without_commondir() {
+    let temp = tempdir().expect("tempdir");
+    let worktree = temp.path().join("worktree");
+    let gitdir = temp.path().join("gitdirs/feature");
+    fs::create_dir_all(&worktree).expect("create worktree");
+    fs::create_dir_all(&gitdir).expect("create gitdir");
+    fs::write(worktree.join(".git"), "gitdir: ../gitdirs/feature\n").expect("write gitfile");
+    let gitdir = gitdir.canonicalize().expect("canonical gitdir");
+    let mut cmd = Command::new("codex");
+    cmd.current_dir(&worktree);
+
+    let wrapped = wrap_command(&cmd, "t-abcd", AgentKind::Codex, false);
+    let wrapped_args = args(&wrapped);
+    let gitdir_mount = self_mount(&gitdir);
+
+    assert!(wrapped_args
+        .windows(2)
+        .any(|pair| pair[0] == "-v" && pair[1] == gitdir_mount));
 }
 
 #[test]

--- a/src/worktree_layout.rs
+++ b/src/worktree_layout.rs
@@ -1,0 +1,66 @@
+// Git worktree layout helpers shared by agent adapters and sandbox wrapping.
+// Exports linked-worktree gitdir and commondir resolution using std fs/path APIs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn resolve_worktree_gitdir(dir: &Path) -> Option<PathBuf> {
+    let git_path = dir.join(".git");
+    let gitfile = worktree_gitfile(&git_path)?;
+    let content = match fs::read_to_string(&gitfile) {
+        Ok(content) => content,
+        Err(err) => {
+            eprintln!("warning: failed to read codex worktree gitfile: {err}");
+            return None;
+        }
+    };
+    let Some(raw_path) = content.lines().find_map(|line| line.strip_prefix("gitdir:")) else {
+        eprintln!("warning: failed to parse codex worktree gitfile: {}", gitfile.display());
+        return None;
+    };
+    let path = Path::new(raw_path.trim());
+    let resolved = if path.is_absolute() { path.to_path_buf() } else { dir.join(path) };
+    match fs::canonicalize(resolved) {
+        Ok(path) => Some(path),
+        Err(err) => {
+            eprintln!("warning: failed to resolve codex worktree gitdir: {err}");
+            None
+        }
+    }
+}
+
+pub(crate) fn read_commondir(gitdir: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(gitdir.join("commondir")).ok()?;
+    let path = Path::new(content.trim());
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        gitdir.join(path)
+    };
+    fs::canonicalize(resolved).ok()
+}
+
+fn worktree_gitfile(git_path: &Path) -> Option<PathBuf> {
+    let (gitfile, metadata) = resolve_git_path(git_path)?;
+    if metadata.is_dir() {
+        return None;
+    }
+    if metadata.is_file() {
+        return Some(gitfile);
+    }
+    eprintln!(
+        "warning: codex .git path is neither file nor directory: {}",
+        gitfile.display()
+    );
+    None
+}
+
+fn resolve_git_path(git_path: &Path) -> Option<(PathBuf, fs::Metadata)> {
+    let metadata = fs::symlink_metadata(git_path).ok()?;
+    if metadata.file_type().is_symlink() {
+        let resolved = fs::canonicalize(git_path).ok()?;
+        let metadata = fs::metadata(&resolved).ok()?;
+        return Some((resolved, metadata));
+    }
+    Some((git_path.to_path_buf(), metadata))
+}

--- a/src/worktree_layout.rs
+++ b/src/worktree_layout.rs
@@ -10,12 +10,12 @@ pub(crate) fn resolve_worktree_gitdir(dir: &Path) -> Option<PathBuf> {
     let content = match fs::read_to_string(&gitfile) {
         Ok(content) => content,
         Err(err) => {
-            eprintln!("warning: failed to read codex worktree gitfile: {err}");
+            eprintln!("warning: failed to read worktree gitfile: {err}");
             return None;
         }
     };
     let Some(raw_path) = content.lines().find_map(|line| line.strip_prefix("gitdir:")) else {
-        eprintln!("warning: failed to parse codex worktree gitfile: {}", gitfile.display());
+        eprintln!("warning: failed to parse worktree gitfile: {}", gitfile.display());
         return None;
     };
     let path = Path::new(raw_path.trim());
@@ -23,7 +23,7 @@ pub(crate) fn resolve_worktree_gitdir(dir: &Path) -> Option<PathBuf> {
     match fs::canonicalize(resolved) {
         Ok(path) => Some(path),
         Err(err) => {
-            eprintln!("warning: failed to resolve codex worktree gitdir: {err}");
+            eprintln!("warning: failed to resolve worktree gitdir: {err}");
             None
         }
     }
@@ -49,7 +49,7 @@ fn worktree_gitfile(git_path: &Path) -> Option<PathBuf> {
         return Some(gitfile);
     }
     eprintln!(
-        "warning: codex .git path is neither file nor directory: {}",
+        "warning: .git path is neither file nor directory: {}",
         gitfile.display()
     );
     None


### PR DESCRIPTION
Fixes #127.

Sibling fix to #126: container `--sandbox` mode (`src/sandbox.rs::wrap_command`) only mounted `cwd`, so when `cwd` is a **linked git worktree** the shared object database (under the main repo's `.git/`) was invisible inside the Apple-container sandbox — `git add`/`git commit` couldn't reach it (same silent-loss class as #126, but the opt-in container path).

## Changes
- **New `src/worktree_layout.rs`** — extracted `resolve_worktree_gitdir` + `read_commondir` (previously private in `codex.rs`) into a shared `pub(crate)` module; `codex.rs` now uses them (duplicated copies removed, ~60 lines lighter). Warning strings made generic (no longer say "codex").
- **`wrap_command`** now adds bind mounts for a linked worktree's git directories, computed by `worktree_git_mounts` with a **non-overlapping** decision table:

  | Layout | Mounts |
  |--------|--------|
  | Standard worktree (gitdir under commondir) | commondir only (covers gitdir) |
  | Separate gitdir (not under commondir) | commondir + gitdir |
  | No resolvable commondir | gitdir (fallback) |
  | Normal checkout (`.git` is a dir under cwd) | none |

  Mounts use identical host:container paths so git resolves them at the same absolute path inside the container; `push_git_mount` skips anything already under `cwd` and exact duplicates.
- `wrap_command` refactored into sub-50-line helpers; sandbox tests moved to `src/sandbox_tests.rs` to keep `sandbox.rs` under 300 lines.

## Why no overlapping mounts
The per-worktree gitdir is always a descendant of commondir, so mounting both would be an overlapping bind mount (a path + its ancestor) — a risk if the Apple `container` CLI is strict. Mounting commondir alone provably exposes the gitdir, so the redundant child mount is skipped. (Raised by the cross-audit.)

## Tests (9 sandbox tests pass)
- `wrap_command_mounts_linked_worktree_gitdirs` — standard layout asserts commondir mounted, no redundant gitdir mount
- `wrap_command_mounts_worktree_gitdir_without_commondir` — fallback path
- `wrap_command_skips_git_mounts_for_regular_checkout` — normal checkout → zero git mounts

## Audit
Cross-audited by gemini against an adversarial checklist (helper-extraction parity, mount correctness, dedup, panic-safety, test rigor) → **SHIP**. The one residual risk it flagged (overlapping mounts) is eliminated by the hardening commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
