### PR TITLE
fix(worktree): reusing a --worktree name no longer orphans prior task's unmerged commit (#137)

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -245,6 +245,9 @@ pub fn create_worktree(
             AID_BRANCH_PREFIXES.join(", ")
         );
     }
+    if branch_exists {
+        reconcile::ensure_branch_force_reset_is_safe(repo_dir, branch, base_branch)?;
+    }
     let _ = Command::new("git")
         .args([
             "-C",

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -245,9 +245,11 @@ pub fn create_worktree(
             AID_BRANCH_PREFIXES.join(", ")
         );
     }
-    if branch_exists {
-        reconcile::ensure_branch_force_reset_is_safe(repo_dir, branch, base_branch)?;
-    }
+    let reset_base = if branch_exists {
+        reconcile::ensure_branch_force_reset_is_safe(repo_dir, branch, base_branch)?
+    } else {
+        base_branch.unwrap_or("HEAD").to_string()
+    };
     let _ = Command::new("git")
         .args([
             "-C",
@@ -255,7 +257,7 @@ pub fn create_worktree(
             "branch",
             "-f",
             branch,
-            base_branch.unwrap_or("HEAD"),
+            &reset_base,
         ])
         .output();
     let out = Command::new("git")

--- a/src/worktree/reconcile.rs
+++ b/src/worktree/reconcile.rs
@@ -71,6 +71,23 @@ pub(super) fn maybe_refresh_existing_worktree(
     Ok(())
 }
 
+pub(super) fn ensure_branch_force_reset_is_safe(
+    repo_dir: &Path,
+    branch: &str,
+    base_branch: Option<&str>,
+) -> Result<()> {
+    let base_ref = base_branch.unwrap_or("HEAD");
+    let unique_commits = rev_list_count(repo_dir, &format!("{base_ref}..{branch}"))?;
+    if unique_commits > 0 {
+        anyhow::bail!(
+            "Branch {branch} has {unique_commits} unmerged commit(s) not on {base_ref}; \
+             refusing to force-reset (would orphan them). Run: aid worktree remove {branch}, \
+             or use a different --worktree name."
+        );
+    }
+    Ok(())
+}
+
 fn rev_parse(repo_dir: &Path, rev: &str) -> Result<String> {
     let output = Command::new("git")
         .args(["-C", &repo_dir.to_string_lossy(), "rev-parse", rev])

--- a/src/worktree/reconcile.rs
+++ b/src/worktree/reconcile.rs
@@ -75,9 +75,10 @@ pub(super) fn ensure_branch_force_reset_is_safe(
     repo_dir: &Path,
     branch: &str,
     base_branch: Option<&str>,
-) -> Result<()> {
+) -> Result<String> {
     let base_ref = base_branch.unwrap_or("HEAD");
-    let unique_commits = rev_list_count(repo_dir, &format!("{base_ref}..{branch}"))?;
+    let base_oid = rev_parse(repo_dir, base_ref)?;
+    let unique_commits = rev_list_count(repo_dir, &format!("{base_oid}..{branch}"))?;
     if unique_commits > 0 {
         anyhow::bail!(
             "Branch {branch} has {unique_commits} unmerged commit(s) not on {base_ref}; \
@@ -85,7 +86,7 @@ pub(super) fn ensure_branch_force_reset_is_safe(
              or use a different --worktree name."
         );
     }
-    Ok(())
+    Ok(base_oid)
 }
 
 fn rev_parse(repo_dir: &Path, rev: &str) -> Result<String> {

--- a/src/worktree/stale_tests.rs
+++ b/src/worktree/stale_tests.rs
@@ -188,3 +188,50 @@ fn create_worktree_errors_when_head_drifted_and_dirty() {
         &["worktree", "remove", "--force", &info.path.to_string_lossy()],
     );
 }
+
+#[test]
+fn create_worktree_rejects_pruned_branch_with_unmerged_commit() {
+    let _permit = test_subprocess::acquire();
+    let repo = init_repo();
+    let branch = unique_branch("feat/pruned-unmerged");
+    let info = create_worktree(repo.path(), branch.as_str(), None).unwrap();
+
+    std::fs::write(info.path.join("agent.txt"), "agent\n").unwrap();
+    git(info.path.as_path(), &["add", "agent.txt"]);
+    git(info.path.as_path(), &["commit", "-m", "agent commit"]);
+    std::fs::remove_dir_all(&info.path).unwrap();
+
+    let err = create_worktree(repo.path(), branch.as_str(), None).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains(branch.as_str()), "msg: {msg}");
+    assert!(msg.contains("unmerged commit(s)"), "msg: {msg}");
+    assert!(msg.contains("refusing to force-reset"), "msg: {msg}");
+    assert!(msg.contains("would orphan them"), "msg: {msg}");
+}
+
+#[test]
+fn create_worktree_allows_pruned_branch_without_unmerged_commit() {
+    let _permit = test_subprocess::acquire();
+    let repo = init_repo();
+    let branch = unique_branch("feat/pruned-merged");
+    let info = create_worktree(repo.path(), branch.as_str(), None).unwrap();
+
+    std::fs::write(info.path.join("merged.txt"), "merged\n").unwrap();
+    git(info.path.as_path(), &["add", "merged.txt"]);
+    git(info.path.as_path(), &["commit", "-m", "merged commit"]);
+    git(repo.path(), &["merge", "--no-edit", branch.as_str()]);
+    std::fs::remove_dir_all(&info.path).unwrap();
+
+    let recreated = create_worktree(repo.path(), branch.as_str(), None).unwrap();
+
+    assert_eq!(recreated.path, aid_worktree_path(repo.path(), &branch));
+    assert!(recreated.path.exists());
+    assert_eq!(
+        git_output(repo.path(), &["rev-parse", "HEAD"]),
+        git_output(recreated.path.as_path(), &["rev-parse", "HEAD"])
+    );
+    git(
+        repo.path(),
+        &["worktree", "remove", "--force", &recreated.path.to_string_lossy()],
+    );
+}


### PR DESCRIPTION
Fixes #137.

## Problem
Dispatching a second task with the same `--worktree <branch>` as a completed task silently orphaned the prior task's commit. Two reuse paths had inconsistent safety:
- **Safe**: `reconcile::maybe_refresh_existing_worktree` (dir exists) errors when the worktree has commits not on HEAD.
- **Unsafe**: the fallback "existing branch" path (dir pruned, branch ref kept) ran `git branch -f <branch> HEAD` unconditionally for aid-managed branches — orphaning unmerged commits.

The lifecycle forces users into the unsafe path: on completion, aid prunes the worktree dir but keeps the branch, so reuse always missed reconcile and hit the fallback.

## Fix
- New `reconcile::ensure_branch_force_reset_is_safe`: resolves the base ref to a concrete OID **once**, refuses the force-reset (clear error pointing to `aid worktree remove`) when `<base_oid>..<branch>` has unmerged commits, and **returns that OID**.
- The fallback in `create_worktree` uses the returned OID for `git branch -f` — the same commit object is used for the safety check and the reset, closing a TOCTOU window where symbolic `HEAD` could resolve differently between check and reset (found in cross-audit).

## Tests
- `create_worktree_rejects_pruned_branch_with_unmerged_commit` — reuse with unmerged commit + pruned dir → errors, commit preserved.
- `create_worktree_allows_pruned_branch_without_unmerged_commit` — fully-merged branch + pruned dir → force-reset path intact.

## Verification
Cross-audited (2 rounds, codex, read-only, adversarial checklist) → SHIP. `cargo check` + `cargo test pruned_branch` pass; full `cargo test worktree` 117 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)