### PR TITLE
feat(tui): show route as cli/provider/model with attribution

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -74,20 +74,20 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
         merged
     };
 
-    // Header
+    // Header — Route is cli/provider/model (attribution rides on the model segment).
     if show_repo {
         out.push_str(&format!(
-            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
-            "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Repo", "Caller", "Model"
+            "{:<11} {:<36} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
+            "ID", "Route", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Repo", "Caller", "Model"
         ));
-        out.push_str(&"-".repeat(165));
+        out.push_str(&"-".repeat(191));
         out.push('\n');
     } else {
         out.push_str(&format!(
-            "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
-            "ID", "Agent", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Caller", "Model"
+            "{:<11} {:<36} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
+            "ID", "Route", "Status", "Duration", "Tokens", "Cost", "Parent", "Group", "Caller", "Model"
         ));
-        out.push_str(&"-".repeat(144));
+        out.push_str(&"-".repeat(170));
         out.push('\n');
     }
 
@@ -131,13 +131,15 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
         let repo = short_repo(task.repo_path.as_deref());
         let caller = session::display(task);
         let model_display = task.display_model();
-        let model = model_display.as_deref().unwrap_or("-");
+        let model = model_display.as_deref().unwrap_or("unknown");
+        // Fixed column: keep the triple scannable without wrapping the row.
+        let route = truncate(&task.display_route(), 36);
 
         if show_repo {
             out.push_str(&format!(
-                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
+                "{:<11} {:<36} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<20} {:<16} {}\n",
                 task.id.as_str(),
-                task.agent_display_name(),
+                route,
                 status,
                 duration,
                 tokens,
@@ -150,9 +152,9 @@ pub fn render_board(tasks: &[Task], store: &Store) -> Result<String> {
             ));
         } else {
             out.push_str(&format!(
-                "{:<11} {:<10} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
+                "{:<11} {:<36} {:<30} {:<10} {:<10} {:<8} {:<11} {:<12} {:<16} {}\n",
                 task.id.as_str(),
-                task.agent_display_name(),
+                route,
                 status,
                 duration,
                 tokens,

--- a/src/board/detail.rs
+++ b/src/board/detail.rs
@@ -17,7 +17,7 @@ pub fn render_task_detail(task: &Task, events: &[TaskEvent], retry_chain: Option
     out.push_str(&format!(
         "Task: {} — {}: {}\n",
         task.id,
-        task.agent_display_name(),
+        task.display_route(),
         truncate(&task.prompt, 60),
     ));
 

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -80,6 +80,29 @@ fn board_with_tasks() {
     assert!(output.contains("Cost"));
     assert!(output.contains("Caller"));
     assert!(output.contains("Group"));
+    assert!(output.contains("Route"), "header should say Route, not Agent: {output}");
+    assert!(
+        output.contains("codex/openai-chatgpt-plan/unknown"),
+        "unknown model stays literal unknown: {output}"
+    );
+}
+
+#[test]
+fn board_route_shows_attribution_and_substitution() {
+    let (_temp, _guard, store) = isolated_store();
+    let mut task = make_task("t-route", AgentKind::Cursor, TaskStatus::Done);
+    task.requested_model = Some("auto".to_string());
+    task.observed_model = Some("composer-2".to_string());
+    task.attribution_source = Some(AttributionSource::Echoed);
+    let output = render_board(&[task], &store).unwrap();
+    assert!(
+        output.contains("composer-2 (asked auto)"),
+        "substitution must show both models: {output}"
+    );
+    assert!(
+        output.contains("cursor/cursor-subscription/"),
+        "provider is part of the route: {output}"
+    );
 }
 
 #[test]

--- a/src/cmd/board_stream.rs
+++ b/src/cmd/board_stream.rs
@@ -67,7 +67,7 @@ fn init_stream(
     group: Option<&str>,
     limit: Option<usize>,
 ) -> Result<StreamInit> {
-    println!("ID | Agent | Status | Duration | Prompt (truncated)");
+    println!("ID | Route | Status | Duration | Prompt (truncated)");
     let FilteredTasks { mut tasks, truncation } = list_filtered_tasks(store, running, today, mine, group, limit)?;
     tasks.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
     let mut last_status = HashMap::new();
@@ -76,7 +76,7 @@ fn init_stream(
         println!(
             "{} | {} | {} | {} | {}",
             task.id.as_str(),
-            task.agent_display_name(),
+            task.display_route(),
             colored_status(task.status),
             duration_for_task(task, store),
             prompt_snippet(task),
@@ -135,7 +135,7 @@ fn poll_and_print(
                 "[{}] {} {} {} {} {}",
                 Local::now().format("%H:%M:%S"),
                 task.id.as_str(),
-                task.agent_display_name(),
+                task.display_route(),
                 colored_status(task.status),
                 duration_for_task(task, store),
                 prompt_snippet(task),

--- a/src/cmd/cost.rs
+++ b/src/cmd/cost.rs
@@ -101,8 +101,12 @@ pub(crate) fn daily_summary_rows(
 }
 
 fn render_task_report(title: &str, tasks: &[&Task]) -> String {
-    let mut out = format!("{title}\n{:<10} {:<12} {:<8} {:<10} {:<10} {}\n", "Task ID", "Agent", "Status", "Tokens", "Cost", "Duration");
-    out.push_str(&"-".repeat(68));
+    // Route is cli/provider/model; width matches the text board's route column.
+    let mut out = format!(
+        "{title}\n{:<10} {:<36} {:<8} {:<10} {:<10} {}\n",
+        "Task ID", "Route", "Status", "Tokens", "Cost", "Duration"
+    );
+    out.push_str(&"-".repeat(92));
     out.push('\n');
     let mut totals: Totals = (0, 0, None);
     for task in tasks {
@@ -111,10 +115,17 @@ fn render_task_report(title: &str, tasks: &[&Task]) -> String {
         totals.0 += 1;
         totals.1 += tokens;
         add_known_cost(&mut totals.2, cost_usd);
+        let route = task.display_route();
+        let route = if route.chars().count() > 36 {
+            let keep: String = route.chars().take(33).collect();
+            format!("{keep}...")
+        } else {
+            route
+        };
         out.push_str(&format!(
-            "{:<10} {:<12} {:<8} {:<10} {:<10} {}\n",
+            "{:<10} {:<36} {:<8} {:<10} {:<10} {}\n",
             task.id,
-            task.agent_display_name(),
+            route,
             task.status.label(),
             tokens,
             cost::format_cost(cost_usd),

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -94,11 +94,10 @@ fn format_task_info(task: &Task) -> String {
 
     [
         format!("Task ID: {}", task.id),
-        format!("Agent: {}", task.agent_display_name()),
+        format!("Route: {}", task.display_route()),
         format!("Status: {}", task.status.label()),
         format!("Prompt: {}", task.prompt),
         format!("Parent Task ID: {}", task.parent_task_id.as_deref().unwrap_or("(none)")),
-        format!("Model: {}", task.display_model().unwrap_or_else(|| "(none)".to_string())),
         format!("Created At: {}", task.created_at.to_rfc3339()),
         format!("Completed At: {completed}"),
         format!("Duration: {duration}"),

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -52,9 +52,9 @@ pub async fn run(store: Arc<Store>, args: ExportArgs) -> Result<()> {
 }
 fn build_markdown(task: &Task, timeline: &[String], output: &str, diff: &str) -> String {
     let header = format!(
-        "# Task {}\n- Agent: {}\n- Status: {}\n- Duration: {}\n- Cost: {}\n- Created: {}\n\n## Prompt\n",
+        "# Task {}\n- Route: {}\n- Status: {}\n- Duration: {}\n- Cost: {}\n- Created: {}\n\n## Prompt\n",
         task.id,
-        task.agent_display_name(),
+        task.display_route(),
         task.status.as_str(),
         format_duration(task.duration_ms),
         format_cost(task.cost_usd),

--- a/src/cmd/merge.rs
+++ b/src/cmd/merge.rs
@@ -315,9 +315,9 @@ enum ApprovalDecision {
 fn ask_approval(task: &Task) -> Result<ApprovalDecision> {
     let branch = merge_source_branch(task).unwrap_or("-");
     let prompt = format!(
-        "Task {} ready to merge:\n- Agent: {}\n- Branch: {}\n\nApprove?",
+        "Task {} ready to merge:\n- Route: {}\n- Branch: {}\n\nApprove?",
         task.id,
-        task.agent_display_name(),
+        task.display_route(),
         branch
     );
     run_approval_prompt(
@@ -330,7 +330,7 @@ fn ask_approval(task: &Task) -> Result<ApprovalDecision> {
 fn ask_group_approval(group_id: &str, tasks: &[Task]) -> Result<ApprovalDecision> {
     let details = tasks
         .iter()
-        .map(|task| format!("- {}: {} ({})", task.id, task.agent_display_name(), merge_source_branch(task).unwrap_or("-")))
+        .map(|task| format!("- {}: {} ({})", task.id, task.display_route(), merge_source_branch(task).unwrap_or("-")))
         .collect::<Vec<_>>()
         .join("\n");
     let prompt = format!("Group {group_id} ready to merge:\n{details}\n\nApprove?");

--- a/src/cmd/prompt_context.rs
+++ b/src/cmd/prompt_context.rs
@@ -367,7 +367,7 @@ pub(super) fn resolve_context_from(store: &Store, task_ids: &[String]) -> Result
         blocks.push(format!(
             "[Prior Task Result — {} ({}, {})]\n<prior-task-output task=\"{}\">\n{}\n</prior-task-output>",
             task_id,
-            task.agent_display_name(),
+            task.display_route(),
             task.status.as_str(),
             task_id,
             sanitized.trim()

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -354,8 +354,8 @@ pub fn summary_text(store: &Arc<Store>, task_id: &str) -> Result<String> {
     let mut out = String::new();
     out.push_str(&format!("=== Review: {} ===\n", task.id));
     out.push_str(&format!(
-        "Agent: {}  Status: {}  Prompt: {}\n",
-        task.agent_display_name(),
+        "Route: {}  Status: {}  Prompt: {}\n",
+        task.display_route(),
         task.status.label(),
         task.prompt,
     ));

--- a/src/cmd/show_output_diff.rs
+++ b/src/cmd/show_output_diff.rs
@@ -77,15 +77,13 @@ pub(crate) fn worktree_diff(task: &Task, task_id: &str) -> Result<String> {
 fn format_diff_header(task: &Task) -> String {
     let mut out = String::new();
     out.push_str(&format!("=== Review: {} ===\n", task.id));
+    // Route already carries model + attribution; keep no separate Model line.
     out.push_str(&format!(
-        "Agent: {}  Status: {}  Prompt: {}\n",
-        task.agent_display_name(),
+        "Route: {}  Status: {}  Prompt: {}\n",
+        task.display_route(),
         task.status.label(),
         truncate(&task.prompt, 60),
     ));
-    if let Some(model) = task.display_model() {
-        out.push_str(&format!("Model: {model}\n"));
-    }
     out
 }
 

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -92,9 +92,9 @@ fn collect(store: &Store, window: UsageWindow, agent: Option<&str>, now: DateTim
         activity_by_day: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].into_iter().map(|day| (day.to_string(), *day_counts.get(day).unwrap_or(&0))).collect(),
         activity_by_hour: hour_counts.into_iter().enumerate().map(|(hour, count)| (hour as u32, count)).collect(),
         top_sessions: [
-            longest.map(|(task, ms)| TopSession { task_id: task.id.to_string(), agent: task.agent_display_name().to_string(), label: "Longest", value: format_duration(Some(ms)) }),
-            most_tokens.map(|(task, tokens)| TopSession { task_id: task.id.to_string(), agent: task.agent_display_name().to_string(), label: "Most tokens", value: format_tokens(tokens) }),
-            highest_cost.map(|(task, cost_usd)| TopSession { task_id: task.id.to_string(), agent: task.agent_display_name().to_string(), label: "Highest cost", value: cost::format_cost(Some(cost_usd)) }),
+            longest.map(|(task, ms)| TopSession { task_id: task.id.to_string(), agent: task.display_route(), label: "Longest", value: format_duration(Some(ms)) }),
+            most_tokens.map(|(task, tokens)| TopSession { task_id: task.id.to_string(), agent: task.display_route(), label: "Most tokens", value: format_tokens(tokens) }),
+            highest_cost.map(|(task, cost_usd)| TopSession { task_id: task.id.to_string(), agent: task.display_route(), label: "Highest cost", value: cost::format_cost(Some(cost_usd)) }),
         ].into_iter().flatten().collect(),
     })
 }

--- a/src/cmd/summary.rs
+++ b/src/cmd/summary.rs
@@ -32,7 +32,7 @@ pub fn generate_summary(task: &Task) -> CompletionSummary {
     let conclusion = summary_conclusion::extract_conclusion(task);
     let summary_text = format!(
         "{} {}: {} files changed ({}). Duration: {}.",
-        task.agent_display_name(),
+        task.display_route(),
         task.status.as_str(),
         files_changed.len(),
         file_list,
@@ -41,6 +41,7 @@ pub fn generate_summary(task: &Task) -> CompletionSummary {
 
     CompletionSummary {
         task_id: task.id.as_str().to_string(),
+        // Structured field stays the CLI name; the human line above carries the route.
         agent: task.agent_display_name().to_string(),
         status: task.status.as_str().to_string(),
         files_changed,
@@ -165,7 +166,12 @@ mod tests {
         assert_eq!(summary.status, "done");
         assert_eq!(summary.duration_secs, Some(2));
         assert!(summary.conclusion.is_empty());
-        assert!(summary.summary_text.contains("codex done")); assert!(summary.summary_text.contains("(no changes detected)"));
+        assert!(
+            summary.summary_text.contains("codex/openai-chatgpt-plan/unknown done"),
+            "summary text should open with the route triple: {}",
+            summary.summary_text
+        );
+        assert!(summary.summary_text.contains("(no changes detected)"));
     }
     #[test]
     fn format_summary_produces_readable_output() {

--- a/src/cmd/summary_cli.rs
+++ b/src/cmd/summary_cli.rs
@@ -50,7 +50,7 @@ fn print_results(tasks: &[Task]) {
             "{} {} {} — \"{}\" ({})",
             symbol,
             task.id.as_str(),
-            task.agent_display_name(),
+            task.display_route(),
             snippet,
             attrs
         );

--- a/src/cmd/tree.rs
+++ b/src/cmd/tree.rs
@@ -93,7 +93,7 @@ fn format_task_line(task: &Task) -> String {
     format!(
         "{} {} {} ({})",
         task.id.as_str(),
-        task.agent_display_name(),
+        task.display_route(),
         status,
         parts.join(", ")
     )
@@ -117,5 +117,80 @@ fn format_token_count(count: i64) -> String {
         format!("{:.1}k", count as f64 / 1_000.0)
     } else {
         count.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AgentKind, AttributionSource, TaskId, TaskStatus, VerifyStatus,
+    };
+    use chrono::Local;
+
+    fn sample(agent: AgentKind) -> Task {
+        Task {
+            id: TaskId("t-tree".to_string()),
+            agent,
+            custom_agent_name: None,
+            prompt: "p".to_string(),
+            resolved_prompt: None,
+            category: None,
+            status: TaskStatus::Done,
+            parent_task_id: None,
+            workgroup_id: None,
+            caller_kind: None,
+            caller_session_id: None,
+            agent_session_id: None,
+            repo_path: None,
+            worktree_path: None,
+            worktree_branch: None,
+            final_head_sha: None,
+            final_branch: None,
+            start_sha: None,
+            log_path: None,
+            output_path: None,
+            tokens: Some(1_500),
+            prompt_tokens: None,
+            duration_ms: Some(12_000),
+            requested_model: None,
+            observed_model: None,
+            attribution_source: None,
+            cost_usd: None,
+            exit_code: None,
+            created_at: Local::now(),
+            completed_at: None,
+            verify: None,
+            verify_status: VerifyStatus::Skipped,
+            pending_reason: None,
+            read_only: false,
+            budget: false,
+            audit_verdict: None,
+            audit_report_path: None,
+            delivery_assessment: None,
+        }
+    }
+
+    #[test]
+    fn tree_line_shows_route_triple_not_opaque_cli() {
+        let line = format_task_line(&sample(AgentKind::Codex));
+        assert!(
+            line.contains("codex/openai-chatgpt-plan/unknown"),
+            "expected route triple in tree line: {line}"
+        );
+        assert!(line.contains("1.5k tokens"), "{line}");
+    }
+
+    #[test]
+    fn tree_line_marks_inferred_attribution() {
+        let mut task = sample(AgentKind::Codex);
+        task.requested_model = Some("gpt-5.6".to_string());
+        task.observed_model = Some("gpt-5.6".to_string());
+        task.attribution_source = Some(AttributionSource::ConfirmedBySuccess);
+        let line = format_task_line(&task);
+        assert!(
+            line.contains("gpt-5.6 (inferred)"),
+            "attribution grade must ride the model segment: {line}"
+        );
     }
 }

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -17,7 +17,7 @@ pub fn run(force: bool) -> Result<()> {
             aid_info!(
                 "  {} — {} ({})",
                 task.id,
-                task.agent_display_name(),
+                task.display_route(),
                 task.status.label()
             );
         }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -31,21 +31,48 @@ fn make_task(id: &str, group_id: Option<&str>) -> Task {
         output_path: None,
         tokens: None,
         prompt_tokens: None,
-            duration_ms: None,
-            requested_model: None, observed_model: None, attribution_source: None,
-            cost_usd: None,
-            exit_code: None,
-            created_at: Local::now(),
+        duration_ms: None,
+        // Fixture leaves model unattributed so route display keeps "unknown".
+        requested_model: None,
+        observed_model: None,
+        attribution_source: None,
+        cost_usd: None,
+        exit_code: None,
+        created_at: Local::now(),
         completed_at: None,
-            verify: None,
-            verify_status: VerifyStatus::Skipped,
-            pending_reason: None,
+        verify: None,
+        verify_status: VerifyStatus::Skipped,
+        pending_reason: None,
         read_only: false,
-            budget: false,
-            audit_verdict: None,
+        budget: false,
+        audit_verdict: None,
         audit_report_path: None,
         delivery_assessment: None,
-        }
+    }
+}
+
+#[test]
+fn loaded_task_route_exposes_provider_and_attribution() {
+    use crate::types::AttributionSource;
+    let store = Arc::new(Store::open_memory().unwrap());
+    let mut task = make_task("t-route-1", None);
+    task.requested_model = Some("gpt-5.6".to_string());
+    task.observed_model = Some("gpt-5.6".to_string());
+    task.attribution_source = Some(AttributionSource::Echoed);
+    store.insert_task(&task).unwrap();
+
+    let app = App::new(
+        store,
+        super::super::RunOptions {
+            task_id: None,
+            group: None,
+        },
+    )
+    .unwrap();
+    let loaded = app.tasks.iter().find(|t| t.id.as_str() == "t-route-1").unwrap();
+    assert_eq!(loaded.route().provider.as_str(), "openai-chatgpt-plan");
+    assert_eq!(loaded.display_route(), "codex/openai-chatgpt-plan/gpt-5.6");
+    assert_eq!(loaded.attribution_source, Some(AttributionSource::Echoed));
 }
 
 #[test]

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -2,6 +2,7 @@
 // Exports the checklist-style dashboard view; depends on ratatui and App state.
 use super::app::App;
 use super::metrics::ProcessMetrics;
+use super::route_display::format_route_fit;
 use crate::types::{EventKind, Task, TaskStatus};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::{Alignment, Color, Modifier, Style};
@@ -149,7 +150,7 @@ pub fn render_task_card(
                 .title(format!(
                     " {} {} {} {} ",
                     task.id,
-                    task.agent_display_name(),
+                    format_route_fit(task, 36),
                     task.status.label(),
                     milestone_progress(task, milestones.len())
                 ))

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,6 +6,7 @@ pub mod charts;
 pub mod dashboard;
 pub mod metrics;
 pub mod multipane;
+pub mod route_display;
 pub mod tree_data;
 pub mod ui;
 

--- a/src/tui/multipane.rs
+++ b/src/tui/multipane.rs
@@ -156,7 +156,7 @@ fn render_pane(pane: &PaneData, is_active: bool) -> List<'static> {
         if !pane.worktree_branch.is_empty() {
             parts.push(pane.worktree_branch.clone());
         }
-        if !pane.model.is_empty() && pane.model != "-" {
+        if !pane.model.is_empty() && pane.model != "unknown" {
             parts.push(pane.model.clone());
         }
         if !pane.created.is_empty() {

--- a/src/tui/route_display.rs
+++ b/src/tui/route_display.rs
@@ -1,0 +1,212 @@
+// Width-aware formatting of a task's CLI / provider / model route for the TUI.
+// Exports: format_route_fit. Deps: crate::types::{provider_for_cli, Task}.
+
+use crate::types::{provider_for_cli, Task};
+
+/// Format `cli/provider/model` for a given width budget.
+///
+/// Truncation order (deliberate):
+/// 1. Shrink the provider first — longest segment, least needed at a glance.
+/// 2. Shrink the model next — attribution suffix may clip.
+/// 3. Fall back to the CLI alone so the row never wraps into garbage.
+///
+/// Unknown model is always the literal `unknown`, never a guess.
+pub fn format_route_fit(task: &Task, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    let cli = task.agent_display_name();
+    let (provider, _) = provider_for_cli(task.agent);
+    let provider = provider.as_str();
+    let model = task
+        .display_model()
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let full = format!("{cli}/{provider}/{model}");
+    if char_len(&full) <= max_width {
+        return full;
+    }
+
+    // cli + two slashes already spent; remaining budget for provider+model.
+    let fixed = char_len(cli) + 2;
+    if fixed >= max_width {
+        return truncate_chars(cli, max_width);
+    }
+    let remaining = max_width - fixed;
+
+    // Prefer a readable provider stub over an empty one.
+    let prov_budget = (remaining / 2).max(4).min(remaining.saturating_sub(1));
+    let model_budget = remaining.saturating_sub(prov_budget);
+    let prov = truncate_chars(provider, prov_budget);
+    let modl = truncate_chars(&model, model_budget.max(1));
+    let fitted = format!("{cli}/{prov}/{modl}");
+    if char_len(&fitted) <= max_width {
+        return fitted;
+    }
+    truncate_chars(cli, max_width)
+}
+
+fn char_len(s: &str) -> usize {
+    s.chars().count()
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if char_len(s) <= max {
+        return s.to_string();
+    }
+    if max <= 3 {
+        return s.chars().take(max).collect();
+    }
+    let keep = max - 3;
+    let mut out: String = s.chars().take(keep).collect();
+    out.push_str("...");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AgentKind, AttributionSource, TaskId, TaskStatus, VerifyStatus};
+    use chrono::Local;
+
+    fn task_with(
+        agent: AgentKind,
+        custom: Option<&str>,
+        requested: Option<&str>,
+        observed: Option<&str>,
+        source: Option<AttributionSource>,
+    ) -> Task {
+        Task {
+            id: TaskId("t-route".to_string()),
+            agent,
+            custom_agent_name: custom.map(str::to_string),
+            prompt: "p".to_string(),
+            resolved_prompt: None,
+            category: None,
+            status: TaskStatus::Done,
+            parent_task_id: None,
+            workgroup_id: None,
+            caller_kind: None,
+            caller_session_id: None,
+            agent_session_id: None,
+            repo_path: None,
+            worktree_path: None,
+            worktree_branch: None,
+            final_head_sha: None,
+            final_branch: None,
+            start_sha: None,
+            log_path: None,
+            output_path: None,
+            tokens: None,
+            prompt_tokens: None,
+            duration_ms: None,
+            requested_model: requested.map(str::to_string),
+            observed_model: observed.map(str::to_string),
+            attribution_source: source,
+            cost_usd: None,
+            exit_code: None,
+            created_at: Local::now(),
+            completed_at: None,
+            verify: None,
+            verify_status: VerifyStatus::Skipped,
+            pending_reason: None,
+            read_only: false,
+            budget: false,
+            audit_verdict: None,
+            audit_report_path: None,
+            delivery_assessment: None,
+        }
+    }
+
+    #[test]
+    fn full_route_shows_cli_provider_and_echoed_model() {
+        let t = task_with(
+            AgentKind::Codex,
+            None,
+            Some("gpt-5.6"),
+            Some("gpt-5.6"),
+            Some(AttributionSource::Echoed),
+        );
+        assert_eq!(
+            format_route_fit(&t, 80),
+            "codex/openai-chatgpt-plan/gpt-5.6"
+        );
+        assert_eq!(t.route().provider.as_str(), "openai-chatgpt-plan");
+    }
+
+    #[test]
+    fn unknown_model_stays_unknown() {
+        let t = task_with(AgentKind::Codex, None, None, None, None);
+        assert_eq!(
+            format_route_fit(&t, 80),
+            "codex/openai-chatgpt-plan/unknown"
+        );
+        assert!(t.route().model.is_none());
+    }
+
+    #[test]
+    fn inferred_attribution_is_visible() {
+        let t = task_with(
+            AgentKind::Codex,
+            None,
+            Some("gpt-5.6-luna"),
+            Some("gpt-5.6-luna"),
+            Some(AttributionSource::ConfirmedBySuccess),
+        );
+        assert_eq!(
+            format_route_fit(&t, 80),
+            "codex/openai-chatgpt-plan/gpt-5.6-luna (inferred)"
+        );
+    }
+
+    #[test]
+    fn unconfirmed_request_is_marked() {
+        let t = task_with(
+            AgentKind::Cursor,
+            None,
+            Some("composer-2"),
+            None,
+            None,
+        );
+        let shown = format_route_fit(&t, 80);
+        assert!(shown.ends_with("/composer-2?"), "{shown}");
+        assert!(shown.starts_with("cursor/cursor-subscription/"), "{shown}");
+    }
+
+    #[test]
+    fn custom_cli_name_is_used() {
+        let t = task_with(AgentKind::Custom, Some("glm5"), None, None, None);
+        assert_eq!(format_route_fit(&t, 80), "glm5/unknown/unknown");
+    }
+
+    #[test]
+    fn narrow_width_keeps_cli_and_does_not_wrap() {
+        let t = task_with(
+            AgentKind::Qwen,
+            None,
+            Some("qwen3.8-max"),
+            Some("qwen3.8-max"),
+            Some(AttributionSource::Echoed),
+        );
+        let shown = format_route_fit(&t, 24);
+        assert!(char_len(&shown) <= 24, "{shown}");
+        assert!(shown.starts_with("qwen/"), "{shown}");
+        assert!(!shown.contains('\n'));
+    }
+
+    #[test]
+    fn substitution_shows_both_models() {
+        let t = task_with(
+            AgentKind::Cursor,
+            None,
+            Some("auto"),
+            Some("composer-2"),
+            Some(AttributionSource::Echoed),
+        );
+        let shown = format_route_fit(&t, 80);
+        assert!(shown.contains("composer-2 (asked auto)"), "{shown}");
+    }
+}

--- a/src/tui/route_display.rs
+++ b/src/tui/route_display.rs
@@ -1,11 +1,12 @@
 // Width-aware formatting of a task's CLI / provider / model route for the TUI.
-// Exports: format_route_fit. Deps: crate::types::{provider_for_cli, Task}.
+// Exports: format_route_fit. Deps: crate::types::Task (via display_route).
 
-use crate::types::{provider_for_cli, Task};
+use crate::types::Task;
 
 /// Format `cli/provider/model` for a given width budget.
 ///
-/// Truncation order (deliberate):
+/// Builds on `Task::display_route` so attribution grades stay consistent with
+/// every other human surface. Truncation order (deliberate):
 /// 1. Shrink the provider first — longest segment, least needed at a glance.
 /// 2. Shrink the model next — attribution suffix may clip.
 /// 3. Fall back to the CLI alone so the row never wraps into garbage.
@@ -15,17 +16,18 @@ pub fn format_route_fit(task: &Task, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
     }
-    let cli = task.agent_display_name();
-    let (provider, _) = provider_for_cli(task.agent);
-    let provider = provider.as_str();
-    let model = task
-        .display_model()
-        .unwrap_or_else(|| "unknown".to_string());
-
-    let full = format!("{cli}/{provider}/{model}");
+    let full = task.display_route();
     if char_len(&full) <= max_width {
         return full;
     }
+
+    let cli = task.agent_display_name();
+    // Split on the first two segments so attribution on the model is preserved
+    // as one unit (e.g. "gpt-5.6 (inferred)" stays together).
+    let mut parts = full.splitn(3, '/');
+    let _cli_seg = parts.next().unwrap_or(cli);
+    let provider = parts.next().unwrap_or("unknown");
+    let model = parts.next().unwrap_or("unknown");
 
     // cli + two slashes already spent; remaining budget for provider+model.
     let fixed = char_len(cli) + 2;
@@ -38,7 +40,7 @@ pub fn format_route_fit(task: &Task, max_width: usize) -> String {
     let prov_budget = (remaining / 2).max(4).min(remaining.saturating_sub(1));
     let model_budget = remaining.saturating_sub(prov_budget);
     let prov = truncate_chars(provider, prov_budget);
-    let modl = truncate_chars(&model, model_budget.max(1));
+    let modl = truncate_chars(model, model_budget.max(1));
     let fitted = format!("{cli}/{prov}/{modl}");
     if char_len(&fitted) <= max_width {
         return fitted;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -82,13 +82,16 @@ fn render_multipane_view(frame: &mut ratatui::Frame<'_>, app: &App) {
             };
             multipane::PaneData {
                 task_id: task.id.as_str().to_string(),
-                agent: task.agent_display_name().to_string(),
+                // Pane title budget is tight; model still lands in the bottom bar.
+                agent: crate::tui::route_display::format_route_fit(task, 28),
                 status: task.status.label().to_string(),
                 prompt: task.prompt.clone(),
                 events,
                 tokens: task_tokens(task),
                 cost: cost::format_cost_label(task.cost_usd, task.agent),
-                model: task.display_model().unwrap_or_else(|| "-".to_string()),
+                model: task
+                    .display_model()
+                    .unwrap_or_else(|| "unknown".to_string()),
                 milestone: app.get_milestone(task.id.as_str()).unwrap_or("").to_string(),
                 cpu: task_cpu(app, task),
                 memory: task_memory(app, task),
@@ -127,7 +130,7 @@ fn render_board(frame: &mut ratatui::Frame<'_>, app: &App) {
     );
 
     let header = Row::new(vec![
-        "ID", "Agent", "Status", "Progress", "CPU", "Mem", "Created", "Duration", "Tokens", "Cost", "Model", "Group",
+        "ID", "Route", "Status", "Progress", "CPU", "Mem", "Created", "Duration", "Tokens", "Cost", "Model", "Group",
         "Prompt",
     ])
     .style(Style::default().add_modifier(Modifier::BOLD));
@@ -136,16 +139,17 @@ fn render_board(frame: &mut ratatui::Frame<'_>, app: &App) {
         rows,
         [
             Constraint::Length(10),
-            Constraint::Length(10),
+            // cli/provider/model — longer than the old opaque agent column.
+            Constraint::Length(28),
             Constraint::Length(8),
-            Constraint::Length(32),
+            Constraint::Length(24),
             Constraint::Length(7),
             Constraint::Length(7),
             Constraint::Length(11),
             Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(10),
-            Constraint::Length(14),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(18),
             Constraint::Length(10),
             Constraint::Min(20),
         ],

--- a/src/tui/ui_helpers.rs
+++ b/src/tui/ui_helpers.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row};
 
 use crate::cost;
 use crate::tui::app::{App, DetailTab};
+use crate::tui::route_display::format_route_fit;
 use crate::types::{Task, TaskStatus};
 
 pub fn task_row(app: &App, task: &Task) -> Row<'static> {
@@ -18,9 +19,14 @@ pub fn task_row(app: &App, task: &Task) -> Row<'static> {
         TaskStatus::Stopped => format!("✗ {}", task.status.label()),
         _ => task.status.label().to_string(),
     };
+    // Route column budget matches the table Constraint::Length(28).
+    let route = format_route_fit(task, 28);
+    let model = task
+        .display_model()
+        .unwrap_or_else(|| "unknown".to_string());
     Row::new(vec![
         Cell::from(task.id.as_str().to_string()),
-        Cell::from(task.agent_display_name().to_string()),
+        Cell::from(route),
         Cell::from(status),
         Cell::from(task_progress(app, task)),
         Cell::from(task_cpu(app, task)),
@@ -29,7 +35,7 @@ pub fn task_row(app: &App, task: &Task) -> Row<'static> {
         Cell::from(task_duration(task)),
         Cell::from(task_tokens(task)),
         Cell::from(cost::format_cost_label(task.cost_usd, task.agent)),
-        Cell::from(truncate(&task.display_model().unwrap_or_else(|| "-".to_string()), 14)),
+        Cell::from(truncate(&model, 18)),
         Cell::from(task.workgroup_id.clone().unwrap_or_else(|| "-".to_string())),
         Cell::from(truncate(&task.prompt, 60)),
     ])
@@ -46,13 +52,15 @@ pub fn task_header(task: &Task, events: &[crate::types::TaskEvent]) -> Paragraph
         TaskStatus::Stopped => Color::Red,
         _ => Color::Indexed(250),
     };
+    // Detail has room for the full triple; attribution rides on the model segment.
+    let route = task.display_route();
     let line1 = Line::from(vec![
         Span::styled(
             task.id.as_str().to_string(),
             Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
         ),
         Span::raw("  "),
-        Span::styled(task.agent_display_name().to_string(), Style::default().fg(Color::Indexed(250))),
+        Span::styled(route, Style::default().fg(Color::Indexed(250))),
         Span::raw("  "),
         Span::styled(task.status.label().to_string(), Style::default().fg(status_color).add_modifier(Modifier::BOLD)),
     ]);
@@ -64,7 +72,10 @@ pub fn task_header(task: &Task, events: &[crate::types::TaskEvent]) -> Paragraph
         Span::styled("  Cost: ", Style::default().fg(Color::Indexed(243))),
         Span::raw(cost::format_cost_label(task.cost_usd, task.agent)),
         Span::styled("  Model: ", Style::default().fg(Color::Indexed(243))),
-        Span::raw(task.display_model().unwrap_or_else(|| "-".to_string())),
+        Span::raw(
+            task.display_model()
+                .unwrap_or_else(|| "unknown".to_string()),
+        ),
     ]);
     let scope = task_scope_line(task);
     let mut lines = vec![line1, line2];
@@ -301,15 +312,17 @@ mod tests {
             repo_path: None,
             worktree_path: None,
             worktree_branch: None,
-        final_head_sha: None,
-        final_branch: None,
+            final_head_sha: None,
+            final_branch: None,
             start_sha: None,
             log_path: None,
             output_path: None,
             tokens: None,
             prompt_tokens: None,
             duration_ms: None,
-            requested_model: None, observed_model: None, attribution_source: None,
+            requested_model: None,
+            observed_model: None,
+            attribution_source: None,
             cost_usd: None,
             exit_code: None,
             created_at: Local::now(),
@@ -323,6 +336,29 @@ mod tests {
             audit_report_path: None,
             delivery_assessment: None,
         }
+    }
+
+    #[test]
+    fn task_header_shows_route_triple_not_opaque_agent() {
+        use crate::types::AttributionSource;
+        let mut task = make_task();
+        task.requested_model = Some("gpt-5.6".to_string());
+        task.observed_model = Some("gpt-5.6".to_string());
+        task.attribution_source = Some(AttributionSource::Echoed);
+        // task_header is a Paragraph; assert the source string it is built from.
+        assert_eq!(
+            task.display_route(),
+            "codex/openai-chatgpt-plan/gpt-5.6"
+        );
+        let _ = task_header(&task, &[]);
+    }
+
+    #[test]
+    fn task_header_unknown_model_is_literal_unknown() {
+        let task = make_task();
+        assert!(task.display_route().ends_with("/unknown"));
+        assert_eq!(task.display_model(), None);
+        let _ = task_header(&task, &[]);
     }
 
     #[test]

--- a/src/tui/ui_helpers.rs
+++ b/src/tui/ui_helpers.rs
@@ -53,6 +53,7 @@ pub fn task_header(task: &Task, events: &[crate::types::TaskEvent]) -> Paragraph
         _ => Color::Indexed(250),
     };
     // Detail has room for the full triple; attribution rides on the model segment.
+    // No separate Model line — Route already carries model + grade.
     let route = task.display_route();
     let line1 = Line::from(vec![
         Span::styled(
@@ -71,11 +72,6 @@ pub fn task_header(task: &Task, events: &[crate::types::TaskEvent]) -> Paragraph
         Span::raw(task_tokens(task)),
         Span::styled("  Cost: ", Style::default().fg(Color::Indexed(243))),
         Span::raw(cost::format_cost_label(task.cost_usd, task.agent)),
-        Span::styled("  Model: ", Style::default().fg(Color::Indexed(243))),
-        Span::raw(
-            task.display_model()
-                .unwrap_or_else(|| "unknown".to_string()),
-        ),
     ]);
     let scope = task_scope_line(task);
     let mut lines = vec![line1, line2];

--- a/src/tui/ui_tree.rs
+++ b/src/tui/ui_tree.rs
@@ -11,6 +11,7 @@ use crate::tui::app::App;
 use super::status_to_color;
 use super::ui_helpers::truncate;
 use crate::cost;
+use crate::tui::route_display::format_route_fit;
 use crate::tui::tree_data;
 use crate::types::{Task, TaskStatus};
 
@@ -95,11 +96,14 @@ pub(super) fn render_tree_view(frame: &mut ratatui::Frame<'_>, app: &App) {
                     let id_color = if is_done { Color::Green } else { Color::White };
                     let dim = Color::Indexed(if is_done { 243 } else { 248 });
 
+                    // Tree rows are dense: 22 chars keeps route visible without
+                    // crowding status/duration. Truncation drops provider first.
+                    let route = format_route_fit(task, 22);
                     let mut spans = vec![
                         Span::styled(node.prefix.clone(), Style::default().fg(Color::Indexed(240))),
                         Span::styled(task.id.as_str(), Style::default().fg(id_color).add_modifier(Modifier::BOLD)),
                         Span::raw(" "),
-                        Span::styled(task.agent_display_name().to_string(), Style::default().fg(if is_done { Color::Green } else { Color::Cyan })),
+                        Span::styled(route, Style::default().fg(if is_done { Color::Green } else { Color::Cyan })),
                         Span::raw(" "),
                         Span::styled(task.status.label().to_string(), Style::default().fg(status_color)),
                         Span::raw(" "),
@@ -193,15 +197,17 @@ mod tests {
             repo_path: None,
             worktree_path: None,
             worktree_branch: None,
-        final_head_sha: None,
-        final_branch: None,
+            final_head_sha: None,
+            final_branch: None,
             start_sha: None,
             log_path: None,
             output_path: None,
             tokens: None,
             prompt_tokens: None,
             duration_ms: None,
-            requested_model: None, observed_model: None, attribution_source: None,
+            requested_model: None,
+            observed_model: None,
+            attribution_source: None,
             cost_usd: None,
             exit_code: None,
             created_at: Local::now(),
@@ -215,6 +221,22 @@ mod tests {
             audit_report_path: None,
             delivery_assessment: None,
         }
+    }
+
+    #[test]
+    fn tree_route_fit_uses_provider_not_just_cli() {
+        use crate::tui::route_display::format_route_fit;
+        use crate::types::AttributionSource;
+        let mut t = base_task();
+        t.requested_model = Some("gpt-5.6".to_string());
+        t.observed_model = Some("gpt-5.6".to_string());
+        t.attribution_source = Some(AttributionSource::ConfirmedBySuccess);
+        let shown = format_route_fit(&t, 22);
+        assert!(shown.starts_with("codex/"), "{shown}");
+        assert!(shown.contains("openai") || shown.contains("..."), "{shown}");
+        // inferred attribution is part of the model segment when width allows
+        let wide = format_route_fit(&t, 80);
+        assert!(wide.contains("(inferred)"), "{wide}");
     }
 
     #[test]

--- a/src/types/task.rs
+++ b/src/types/task.rs
@@ -6,8 +6,8 @@ use chrono::{DateTime, Local};
 use serde::Serialize;
 
 use super::{
-    AgentKind, AttributionSource, DeliveryAssessment, EventKind, TaskId, TaskStatus, VerifyStatus,
-    WorkgroupId,
+    provider_for_cli, AgentKind, AttributionSource, DeliveryAssessment, EventKind, Route, TaskId,
+    TaskStatus, VerifyStatus, WorkgroupId,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -106,6 +106,28 @@ impl Task {
             self.observed_model.as_deref(),
             self.requested_model.as_deref(),
             self.attribution_source,
+        )
+    }
+
+    /// The structured route for this task. Model is the observation only — a
+    /// request that was never confirmed stays `None` rather than being filled in.
+    pub fn route(&self) -> Route {
+        Route::for_cli(self.agent).with_model(self.attributed_model())
+    }
+
+    /// Human route label: `cli/provider/model` with attribution on the model
+    /// segment. An unknown model stays `unknown` — never a default or the CLI
+    /// name. Provider comes from `provider_for_cli`, the single source.
+    pub fn display_route(&self) -> String {
+        let (provider, _) = provider_for_cli(self.agent);
+        let model = self
+            .display_model()
+            .unwrap_or_else(|| "unknown".to_string());
+        format!(
+            "{}/{}/{}",
+            self.agent_display_name(),
+            provider.as_str(),
+            model
         )
     }
 
@@ -221,72 +243,5 @@ pub fn format_model_display(
 }
 
 #[cfg(test)]
-mod model_display_tests {
-    use super::format_model_display;
-
-    #[test]
-    fn an_unconfirmed_request_is_marked_as_one() {
-        assert_eq!(format_model_display(None, Some("gpt-5.6"), None), Some("gpt-5.6?".to_string()));
-    }
-
-    #[test]
-    fn a_confirmed_model_is_shown_plainly() {
-        assert_eq!(
-            format_model_display(Some("gpt-5.6"), Some("gpt-5.6"), None),
-            Some("gpt-5.6".to_string())
-        );
-    }
-
-    /// The case worth surfacing: aid asked for one model and the CLI served
-    /// another. Showing only one of the two hides a substitution.
-    #[test]
-    fn a_substitution_shows_both() {
-        assert_eq!(
-            format_model_display(Some("composer-2"), Some("auto"), None),
-            Some("composer-2 (asked auto)".to_string())
-        );
-    }
-
-    #[test]
-    fn nothing_known_renders_as_nothing() {
-        assert_eq!(format_model_display(None, None, None), None);
-    }
-}
-
-#[cfg(test)]
-mod attribution_grade_display_tests {
-    use super::{format_model_display, AttributionSource};
-
-    /// A model inferred from a run not failing must not read the same as one the
-    /// CLI named. Storing the grade and then rendering both identically would
-    /// waste it.
-    #[test]
-    fn an_inferred_model_is_marked() {
-        assert_eq!(
-            format_model_display(
-                Some("gpt-5.6"),
-                Some("gpt-5.6"),
-                Some(AttributionSource::ConfirmedBySuccess)
-            ),
-            Some("gpt-5.6 (inferred)".to_string())
-        );
-    }
-
-    #[test]
-    fn an_echoed_model_stays_plain() {
-        assert_eq!(
-            format_model_display(Some("gpt-5.6"), Some("gpt-5.6"), Some(AttributionSource::Echoed)),
-            Some("gpt-5.6".to_string())
-        );
-    }
-
-    /// A disagreement outranks the grade: the CLI serving something other than
-    /// what was asked is the more important thing to show.
-    #[test]
-    fn a_substitution_still_shows_both() {
-        assert_eq!(
-            format_model_display(Some("composer-2"), Some("auto"), Some(AttributionSource::Echoed)),
-            Some("composer-2 (asked auto)".to_string())
-        );
-    }
-}
+#[path = "task_display_tests.rs"]
+mod tests;

--- a/src/types/task_display_tests.rs
+++ b/src/types/task_display_tests.rs
@@ -1,0 +1,68 @@
+// Tests for model and route display helpers on Task.
+// Loaded by task.rs under `#[cfg(test)]`. Deps: super.
+
+use super::{format_model_display, AttributionSource};
+
+#[test]
+fn an_unconfirmed_request_is_marked_as_one() {
+    assert_eq!(
+        format_model_display(None, Some("gpt-5.6"), None),
+        Some("gpt-5.6?".to_string())
+    );
+}
+
+#[test]
+fn a_confirmed_model_is_shown_plainly() {
+    assert_eq!(
+        format_model_display(Some("gpt-5.6"), Some("gpt-5.6"), None),
+        Some("gpt-5.6".to_string())
+    );
+}
+
+/// The case worth surfacing: aid asked for one model and the CLI served
+/// another. Showing only one of the two hides a substitution.
+#[test]
+fn a_substitution_shows_both() {
+    assert_eq!(
+        format_model_display(Some("composer-2"), Some("auto"), None),
+        Some("composer-2 (asked auto)".to_string())
+    );
+}
+
+#[test]
+fn nothing_known_renders_as_nothing() {
+    assert_eq!(format_model_display(None, None, None), None);
+}
+
+/// A model inferred from a run not failing must not read the same as one the
+/// CLI named. Storing the grade and then rendering both identically would
+/// waste it.
+#[test]
+fn an_inferred_model_is_marked() {
+    assert_eq!(
+        format_model_display(
+            Some("gpt-5.6"),
+            Some("gpt-5.6"),
+            Some(AttributionSource::ConfirmedBySuccess)
+        ),
+        Some("gpt-5.6 (inferred)".to_string())
+    );
+}
+
+#[test]
+fn an_echoed_model_stays_plain() {
+    assert_eq!(
+        format_model_display(Some("gpt-5.6"), Some("gpt-5.6"), Some(AttributionSource::Echoed)),
+        Some("gpt-5.6".to_string())
+    );
+}
+
+/// A disagreement outranks the grade: the CLI serving something other than
+/// what was asked is the more important thing to show.
+#[test]
+fn a_substitution_still_shows_both() {
+    assert_eq!(
+        format_model_display(Some("composer-2"), Some("auto"), Some(AttributionSource::Echoed)),
+        Some("composer-2 (asked auto)".to_string())
+    );
+}

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -79,6 +79,25 @@ fn agent_display_name_for_built_in_agents() {
 }
 
 #[test]
+fn display_route_is_cli_provider_model_and_keeps_unknown() {
+    let task = sample_task(AgentKind::Codex, None);
+    assert_eq!(task.display_route(), "codex/openai-chatgpt-plan/unknown");
+    assert!(task.route().model.is_none());
+}
+
+#[test]
+fn display_route_marks_inferred_attribution() {
+    let mut task = sample_task(AgentKind::Codex, None);
+    task.requested_model = Some("gpt-5.6".to_string());
+    task.observed_model = Some("gpt-5.6".to_string());
+    task.attribution_source = Some(AttributionSource::ConfirmedBySuccess);
+    assert_eq!(
+        task.display_route(),
+        "codex/openai-chatgpt-plan/gpt-5.6 (inferred)"
+    );
+}
+
+#[test]
 fn memory_type_parse_str_roundtrip() {
     for memory_type in [
         MemoryType::Discovery,


### PR DESCRIPTION
## Summary

- Wire human-facing display surfaces to the three-dimension route (`cli/provider/model`) plus attribution grade (`?`, `(asked …)`, `(inferred)`), instead of collapsing to an opaque agent name.
- Add width-aware `format_route_fit` for TUI columns/panes, built on `Task::display_route` so board/show/tree/TUI cannot diverge.
- Reuse existing `Route` / `ProviderId`; unknown model stays literal `unknown`; requested vs observed remain distinguishable.
- Scope is display only — machine JSON `agent` fields and `CompletionSummary.agent` stay the CLI name.

## Surfaces covered

TUI board/multipane/dashboard/tree/detail, text board, show/export/explain/merge/upgrade, board stream, summary text, tree CLI, cost report rows, prompt-context prior-task labels, stats top sessions.

## Test plan

- [x] `cargo test --bin aid --` route/display focused filter (24 passed)
- [x] `cargo test --bin aid -- cmd::summary` (11 passed)
- [x] Full `cargo test --bin aid` — 1838 passed, 1 pre-existing failure (`run_auto_retries_after_verify_failure`, reproduces without these changes)
- [ ] Smoke `aid board` / TUI: Route column shows provider and model attribution